### PR TITLE
The edit panel will now be initially hidden in CRUD views.

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/services/AppUserService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/AppUserService.java
@@ -1,10 +1,13 @@
 package uy.com.equipos.panelmanagement.services;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import jakarta.persistence.criteria.Predicate;
 import uy.com.equipos.panelmanagement.data.AppUser;
 import uy.com.equipos.panelmanagement.data.AppUserRepository;
 
@@ -35,6 +38,20 @@ public class AppUserService {
 
     public Page<AppUser> list(Pageable pageable, Specification<AppUser> filter) {
         return repository.findAll(filter, pageable);
+    }
+
+    public Page<AppUser> list(Pageable pageable, String name, String email) {
+        Specification<AppUser> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (name != null && !name.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%"));
+            }
+            if (email != null && !email.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("email")), "%" + email.toLowerCase() + "%"));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return repository.findAll(spec, pageable);
     }
 
     public int count() {

--- a/src/main/java/uy/com/equipos/panelmanagement/services/IncentiveService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/IncentiveService.java
@@ -1,10 +1,13 @@
 package uy.com.equipos.panelmanagement.services;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import jakarta.persistence.criteria.Predicate;
 import uy.com.equipos.panelmanagement.data.Incentive;
 import uy.com.equipos.panelmanagement.data.IncentiveRepository;
 
@@ -35,6 +38,26 @@ public class IncentiveService {
 
     public Page<Incentive> list(Pageable pageable, Specification<Incentive> filter) {
         return repository.findAll(filter, pageable);
+    }
+
+    public Page<Incentive> list(Pageable pageable, String name, String quantityAvailableStr) {
+        Specification<Incentive> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (name != null && !name.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%"));
+            }
+            if (quantityAvailableStr != null && !quantityAvailableStr.isEmpty()) {
+                try {
+                    Integer quantity = Integer.parseInt(quantityAvailableStr);
+                    predicates.add(cb.equal(root.get("quantityAvailable"), quantity));
+                } catch (NumberFormatException e) {
+                    // Si no es un número válido, no se filtra por esta cantidad.
+                    // Se podría loguear el error: System.err.println("Invalid number format for quantityAvailable: " + quantityAvailableStr);
+                }
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return repository.findAll(spec, pageable);
     }
 
     public int count() {

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelService.java
@@ -1,10 +1,14 @@
 package uy.com.equipos.panelmanagement.services;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import jakarta.persistence.criteria.Predicate;
 import uy.com.equipos.panelmanagement.data.Panel;
 import uy.com.equipos.panelmanagement.data.PanelRepository;
 
@@ -35,6 +39,23 @@ public class PanelService {
 
     public Page<Panel> list(Pageable pageable, Specification<Panel> filter) {
         return repository.findAll(filter, pageable);
+    }
+
+    public Page<Panel> list(Pageable pageable, String name, LocalDate created, Boolean active) {
+        Specification<Panel> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (name != null && !name.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%"));
+            }
+            if (created != null) {
+                predicates.add(cb.equal(root.get("created"), created));
+            }
+            if (active != null) {
+                predicates.add(cb.equal(root.get("active"), active));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return repository.findAll(spec, pageable);
     }
 
     public int count() {

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
@@ -1,10 +1,13 @@
 package uy.com.equipos.panelmanagement.services;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import jakarta.persistence.criteria.Predicate;
 import uy.com.equipos.panelmanagement.data.PanelistProperty;
 import uy.com.equipos.panelmanagement.data.PanelistPropertyRepository;
 
@@ -35,6 +38,20 @@ public class PanelistPropertyService {
 
     public Page<PanelistProperty> list(Pageable pageable, Specification<PanelistProperty> filter) {
         return repository.findAll(filter, pageable);
+    }
+
+    public Page<PanelistProperty> list(Pageable pageable, String name, String type) {
+        Specification<PanelistProperty> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (name != null && !name.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%"));
+            }
+            if (type != null && !type.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("type")), "%" + type.toLowerCase() + "%"));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return repository.findAll(spec, pageable);
     }
 
     public int count() {

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
@@ -1,10 +1,14 @@
 package uy.com.equipos.panelmanagement.services;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import jakarta.persistence.criteria.Predicate;
 import uy.com.equipos.panelmanagement.data.Panelist;
 import uy.com.equipos.panelmanagement.data.PanelistRepository;
 
@@ -35,6 +39,39 @@ public class PanelistService {
 
     public Page<Panelist> list(Pageable pageable, Specification<Panelist> filter) {
         return repository.findAll(filter, pageable);
+    }
+
+    public Page<Panelist> list(Pageable pageable, String firstName, String lastName, String email, String phone,
+                               LocalDate dateOfBirth, String occupation, LocalDate lastContacted, LocalDate lastInterviewed) {
+        Specification<Panelist> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (firstName != null && !firstName.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("firstName")), "%" + firstName.toLowerCase() + "%"));
+            }
+            if (lastName != null && !lastName.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("lastName")), "%" + lastName.toLowerCase() + "%"));
+            }
+            if (email != null && !email.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("email")), "%" + email.toLowerCase() + "%"));
+            }
+            if (phone != null && !phone.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("phone")), "%" + phone.toLowerCase() + "%"));
+            }
+            if (dateOfBirth != null) {
+                predicates.add(cb.equal(root.get("dateOfBirth"), dateOfBirth));
+            }
+            if (occupation != null && !occupation.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("occupation")), "%" + occupation.toLowerCase() + "%"));
+            }
+            if (lastContacted != null) {
+                predicates.add(cb.equal(root.get("lastContacted"), lastContacted));
+            }
+            if (lastInterviewed != null) {
+                predicates.add(cb.equal(root.get("lastInterviewed"), lastInterviewed));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return repository.findAll(spec, pageable);
     }
 
     public int count() {

--- a/src/main/java/uy/com/equipos/panelmanagement/services/SurveyService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/SurveyService.java
@@ -1,10 +1,14 @@
 package uy.com.equipos.panelmanagement.services;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import jakarta.persistence.criteria.Predicate;
 import uy.com.equipos.panelmanagement.data.Survey;
 import uy.com.equipos.panelmanagement.data.SurveyRepository;
 
@@ -35,6 +39,23 @@ public class SurveyService {
 
     public Page<Survey> list(Pageable pageable, Specification<Survey> filter) {
         return repository.findAll(filter, pageable);
+    }
+
+    public Page<Survey> list(Pageable pageable, String name, LocalDate initDate, String link) {
+        Specification<Survey> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (name != null && !name.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%"));
+            }
+            if (initDate != null) {
+                predicates.add(cb.equal(root.get("initDate"), initDate));
+            }
+            if (link != null && !link.isEmpty()) {
+                predicates.add(cb.like(cb.lower(root.get("link")), "%" + link.toLowerCase() + "%"));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return repository.findAll(spec, pageable);
     }
 
     public int count() {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
@@ -39,12 +40,17 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
     private final String INCENTIVE_EDIT_ROUTE_TEMPLATE = "incentives/%s/edit";
 
     private final Grid<Incentive> grid = new Grid<>(Incentive.class, false);
+    private Div editorLayoutDiv; // Declarado como miembro de la clase
+
+    // Campos de filtro
+    private TextField nameFilter = new TextField();
+    private TextField quantityAvailableFilter = new TextField();
 
     private TextField name;
     private TextField quantityAvailable;
 
-    private final Button cancel = new Button("Cancel");
-    private final Button save = new Button("Save");
+    private final Button cancel = new Button("Cancelar");
+    private final Button save = new Button("Guardar");
 
     private final BeanValidationBinder<Incentive> binder;
 
@@ -56,26 +62,46 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
         this.incentiveService = incentiveService;
         addClassNames("incentives-view");
 
-        // Create UI
-        SplitLayout splitLayout = new SplitLayout();
+        // Configurar columnas del Grid PRIMERO
+        grid.addColumn(Incentive::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
+        grid.addColumn(Incentive::getQuantityAvailable).setHeader("Cantidad Disponible").setKey("quantityAvailable").setAutoWidth(true);
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 
+        // Create UI - SplitLayout
+        SplitLayout splitLayout = new SplitLayout();
+        // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
+        editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 
-        // Configure Grid
-        grid.addColumn("name").setAutoWidth(true);
-        grid.addColumn("quantityAvailable").setAutoWidth(true);
-        grid.setItems(query -> incentiveService.list(VaadinSpringDataHelpers.toSpringPageRequest(query)).stream());
-        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+        // Configurar placeholders para filtros
+        nameFilter.setPlaceholder("Filtrar por Nombre");
+        quantityAvailableFilter.setPlaceholder("Filtrar por Cantidad");
+
+        // Añadir listeners para refrescar el grid
+        nameFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        quantityAvailableFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+
+        // Configurar el DataProvider del Grid
+        grid.setItems(query -> {
+            String nameVal = nameFilter.getValue();
+            String quantityAvailableStrVal = quantityAvailableFilter.getValue();
+            // La conversión a Integer se manejará en el servicio o al crear la Specification
+            return incentiveService.list(
+                VaadinSpringDataHelpers.toSpringPageRequest(query),
+                nameVal,
+                quantityAvailableStrVal
+            ).stream();
+        });
 
         // when a row is selected or deselected, populate form
         grid.asSingleSelect().addValueChangeListener(event -> {
             if (event.getValue() != null) {
+                editorLayoutDiv.setVisible(true);
                 UI.getCurrent().navigate(String.format(INCENTIVE_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
             } else {
-                clearForm();
+                clearForm(); // clearForm ahora también oculta el editor
                 UI.getCurrent().navigate(IncentivesView.class);
             }
         });
@@ -84,7 +110,7 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
         binder = new BeanValidationBinder<>(Incentive.class);
 
         // Bind fields. This is where you'd define e.g. validation rules
-        binder.forField(quantityAvailable).withConverter(new StringToIntegerConverter("Only numbers are allowed"))
+        binder.forField(quantityAvailable).withConverter(new StringToIntegerConverter("Solo se permiten números"))
                 .bind("quantityAvailable");
 
         binder.bindInstanceFields(this);
@@ -103,15 +129,15 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
                 incentiveService.save(this.incentive);
                 clearForm();
                 refreshGrid();
-                Notification.show("Data updated");
+                Notification.show("Datos actualizados");
                 UI.getCurrent().navigate(IncentivesView.class);
             } catch (ObjectOptimisticLockingFailureException exception) {
                 Notification n = Notification.show(
-                        "Error updating the data. Somebody else has updated the record while you were making changes.");
+                        "Error al actualizar los datos. Otro usuario modificó el registro mientras usted realizaba cambios.");
                 n.setPosition(Position.MIDDLE);
                 n.addThemeVariants(NotificationVariant.LUMO_ERROR);
             } catch (ValidationException validationException) {
-                Notification.show("Failed to update the data. Check again that all values are valid");
+                Notification.show("Fallo al actualizar los datos. Verifique nuevamente que todos los valores sean válidos");
             }
         });
     }
@@ -123,19 +149,25 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
             Optional<Incentive> incentiveFromBackend = incentiveService.get(incentiveId.get());
             if (incentiveFromBackend.isPresent()) {
                 populateForm(incentiveFromBackend.get());
+                editorLayoutDiv.setVisible(true);
             } else {
-                Notification.show(String.format("The requested incentive was not found, ID = %s", incentiveId.get()),
+                Notification.show(String.format("El incentivo solicitado no fue encontrado, ID = %s", incentiveId.get()),
                         3000, Notification.Position.BOTTOM_START);
                 // when a row is selected but the data is no longer available,
                 // refresh grid
                 refreshGrid();
+                if (editorLayoutDiv != null) {
+                    editorLayoutDiv.setVisible(false);
+                }
                 event.forwardTo(IncentivesView.class);
             }
+        } else {
+            clearForm(); // Asegurar que el editor esté oculto si no hay ID
         }
     }
 
     private void createEditorLayout(SplitLayout splitLayout) {
-        Div editorLayoutDiv = new Div();
+        editorLayoutDiv = new Div(); // Instanciar el miembro de la clase
         editorLayoutDiv.setClassName("editor-layout");
 
         Div editorDiv = new Div();
@@ -143,8 +175,8 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
         editorLayoutDiv.add(editorDiv);
 
         FormLayout formLayout = new FormLayout();
-        name = new TextField("Name");
-        quantityAvailable = new TextField("Quantity Available");
+        name = new TextField("Nombre");
+        quantityAvailable = new TextField("Cantidad Disponible");
         formLayout.add(name, quantityAvailable);
 
         editorDiv.add(formLayout);
@@ -167,6 +199,10 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
         wrapper.setClassName("grid-wrapper");
         splitLayout.addToPrimary(wrapper);
         wrapper.add(grid);
+
+        HeaderRow headerRow = grid.appendHeaderRow();
+        headerRow.getCell(grid.getColumnByKey("name")).setComponent(nameFilter);
+        headerRow.getCell(grid.getColumnByKey("quantityAvailable")).setComponent(quantityAvailableFilter);
     }
 
     private void refreshGrid() {
@@ -176,6 +212,9 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
 
     private void clearForm() {
         populateForm(null);
+        if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
+            editorLayoutDiv.setVisible(false);
+        }
     }
 
     private void populateForm(Incentive value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
@@ -23,6 +24,7 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
 import jakarta.annotation.security.PermitAll;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.vaadin.lineawesome.LineAwesomeIconUrl;
@@ -39,6 +41,17 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
     private final String PANELIST_EDIT_ROUTE_TEMPLATE = "panelists/%s/edit";
 
     private final Grid<Panelist> grid = new Grid<>(Panelist.class, false);
+    private Div editorLayoutDiv; // Declarado como miembro de la clase
+
+    // Campos de filtro
+    private TextField firstNameFilter = new TextField();
+    private TextField lastNameFilter = new TextField();
+    private TextField emailFilter = new TextField();
+    private TextField phoneFilter = new TextField();
+    private DatePicker dateOfBirthFilter = new DatePicker();
+    private TextField occupationFilter = new TextField();
+    private DatePicker lastContactedFilter = new DatePicker();
+    private DatePicker lastInterviewedFilter = new DatePicker();
 
     private TextField firstName;
     private TextField lastName;
@@ -49,8 +62,8 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
     private DatePicker lastContacted;
     private DatePicker lastInterviewed;
 
-    private final Button cancel = new Button("Cancel");
-    private final Button save = new Button("Save");
+    private final Button cancel = new Button("Cancelar");
+    private final Button save = new Button("Guardar");
 
     private final BeanValidationBinder<Panelist> binder;
 
@@ -62,32 +75,76 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
         this.panelistService = panelistService;
         addClassNames("panelists-view");
 
-        // Create UI
-        SplitLayout splitLayout = new SplitLayout();
+        // Configurar columnas del Grid PRIMERO
+        grid.addColumn(Panelist::getFirstName).setHeader("Nombre").setKey("firstName").setAutoWidth(true);
+        grid.addColumn(Panelist::getLastName).setHeader("Apellido").setKey("lastName").setAutoWidth(true);
+        grid.addColumn(Panelist::getEmail).setHeader("Correo Electrónico").setKey("email").setAutoWidth(true);
+        grid.addColumn(Panelist::getPhone).setHeader("Teléfono").setKey("phone").setAutoWidth(true);
+        grid.addColumn(Panelist::getDateOfBirth).setHeader("Fecha de Nacimiento").setKey("dateOfBirth").setAutoWidth(true);
+        grid.addColumn(Panelist::getOccupation).setHeader("Ocupación").setKey("occupation").setAutoWidth(true);
+        grid.addColumn(Panelist::getLastContacted).setHeader("Último Contacto").setKey("lastContacted").setAutoWidth(true);
+        grid.addColumn(Panelist::getLastInterviewed).setHeader("Última Entrevista").setKey("lastInterviewed").setAutoWidth(true);
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 
+        // Create UI - SplitLayout
+        SplitLayout splitLayout = new SplitLayout();
+        // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
+        editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 
-        // Configure Grid
-        grid.addColumn("firstName").setAutoWidth(true);
-        grid.addColumn("lastName").setAutoWidth(true);
-        grid.addColumn("email").setAutoWidth(true);
-        grid.addColumn("phone").setAutoWidth(true);
-        grid.addColumn("dateOfBirth").setAutoWidth(true);
-        grid.addColumn("occupation").setAutoWidth(true);
-        grid.addColumn("lastContacted").setAutoWidth(true);
-        grid.addColumn("lastInterviewed").setAutoWidth(true);
-        grid.setItems(query -> panelistService.list(VaadinSpringDataHelpers.toSpringPageRequest(query)).stream());
-        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+        // Configurar placeholders para filtros
+        firstNameFilter.setPlaceholder("Filtrar por Nombre");
+        lastNameFilter.setPlaceholder("Filtrar por Apellido");
+        emailFilter.setPlaceholder("Filtrar por Correo Electrónico");
+        phoneFilter.setPlaceholder("Filtrar por Teléfono");
+        dateOfBirthFilter.setPlaceholder("Filtrar por Fecha de Nacimiento");
+        occupationFilter.setPlaceholder("Filtrar por Ocupación");
+        lastContactedFilter.setPlaceholder("Filtrar por Último Contacto");
+        lastInterviewedFilter.setPlaceholder("Filtrar por Última Entrevista");
+
+        // Añadir listeners para refrescar el grid
+        firstNameFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        lastNameFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        emailFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        phoneFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        dateOfBirthFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        occupationFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        lastContactedFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        lastInterviewedFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+
+        // Configurar el DataProvider del Grid
+        grid.setItems(query -> {
+            String firstNameVal = firstNameFilter.getValue();
+            String lastNameVal = lastNameFilter.getValue();
+            String emailVal = emailFilter.getValue();
+            String phoneVal = phoneFilter.getValue();
+            LocalDate dateOfBirthVal = dateOfBirthFilter.getValue();
+            String occupationVal = occupationFilter.getValue();
+            LocalDate lastContactedVal = lastContactedFilter.getValue();
+            LocalDate lastInterviewedVal = lastInterviewedFilter.getValue();
+
+            return panelistService.list(
+                VaadinSpringDataHelpers.toSpringPageRequest(query),
+                firstNameVal,
+                lastNameVal,
+                emailVal,
+                phoneVal,
+                dateOfBirthVal,
+                occupationVal,
+                lastContactedVal,
+                lastInterviewedVal
+            ).stream();
+        });
 
         // when a row is selected or deselected, populate form
         grid.asSingleSelect().addValueChangeListener(event -> {
             if (event.getValue() != null) {
+                editorLayoutDiv.setVisible(true);
                 UI.getCurrent().navigate(String.format(PANELIST_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
             } else {
-                clearForm();
+                clearForm(); // clearForm ahora también oculta el editor
                 UI.getCurrent().navigate(PanelistsView.class);
             }
         });
@@ -96,7 +153,6 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
         binder = new BeanValidationBinder<>(Panelist.class);
 
         // Bind fields. This is where you'd define e.g. validation rules
-
         binder.bindInstanceFields(this);
 
         cancel.addClickListener(e -> {
@@ -113,15 +169,15 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
                 panelistService.save(this.panelist);
                 clearForm();
                 refreshGrid();
-                Notification.show("Data updated");
+                Notification.show("Datos actualizados");
                 UI.getCurrent().navigate(PanelistsView.class);
             } catch (ObjectOptimisticLockingFailureException exception) {
                 Notification n = Notification.show(
-                        "Error updating the data. Somebody else has updated the record while you were making changes.");
+                        "Error al actualizar los datos. Otro usuario modificó el registro mientras usted realizaba cambios.");
                 n.setPosition(Position.MIDDLE);
                 n.addThemeVariants(NotificationVariant.LUMO_ERROR);
             } catch (ValidationException validationException) {
-                Notification.show("Failed to update the data. Check again that all values are valid");
+                Notification.show("Fallo al actualizar los datos. Verifique nuevamente que todos los valores sean válidos");
             }
         });
     }
@@ -133,19 +189,25 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
             Optional<Panelist> panelistFromBackend = panelistService.get(panelistId.get());
             if (panelistFromBackend.isPresent()) {
                 populateForm(panelistFromBackend.get());
+                editorLayoutDiv.setVisible(true);
             } else {
-                Notification.show(String.format("The requested panelist was not found, ID = %s", panelistId.get()),
+                Notification.show(String.format("El panelista solicitado no fue encontrado, ID = %s", panelistId.get()),
                         3000, Notification.Position.BOTTOM_START);
                 // when a row is selected but the data is no longer available,
                 // refresh grid
                 refreshGrid();
+                if (editorLayoutDiv != null) { // Asegurar que no sea nulo si beforeEnter se llama muy temprano
+                    editorLayoutDiv.setVisible(false);
+                }
                 event.forwardTo(PanelistsView.class);
             }
+        } else {
+            clearForm(); // Asegurar que el editor esté oculto si no hay ID
         }
     }
 
     private void createEditorLayout(SplitLayout splitLayout) {
-        Div editorLayoutDiv = new Div();
+        editorLayoutDiv = new Div(); // Instanciar el miembro de la clase
         editorLayoutDiv.setClassName("editor-layout");
 
         Div editorDiv = new Div();
@@ -153,14 +215,14 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
         editorLayoutDiv.add(editorDiv);
 
         FormLayout formLayout = new FormLayout();
-        firstName = new TextField("First Name");
-        lastName = new TextField("Last Name");
-        email = new TextField("Email");
-        phone = new TextField("Phone");
-        dateOfBirth = new DatePicker("Date Of Birth");
-        occupation = new TextField("Occupation");
-        lastContacted = new DatePicker("Last Contacted");
-        lastInterviewed = new DatePicker("Last Interviewed");
+        firstName = new TextField("Nombre");
+        lastName = new TextField("Apellido");
+        email = new TextField("Correo Electrónico");
+        phone = new TextField("Teléfono");
+        dateOfBirth = new DatePicker("Fecha de Nacimiento");
+        occupation = new TextField("Ocupación");
+        lastContacted = new DatePicker("Último Contacto");
+        lastInterviewed = new DatePicker("Última Entrevista");
         formLayout.add(firstName, lastName, email, phone, dateOfBirth, occupation, lastContacted, lastInterviewed);
 
         editorDiv.add(formLayout);
@@ -183,6 +245,16 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
         wrapper.setClassName("grid-wrapper");
         splitLayout.addToPrimary(wrapper);
         wrapper.add(grid);
+
+        HeaderRow headerRow = grid.appendHeaderRow();
+        headerRow.getCell(grid.getColumnByKey("firstName")).setComponent(firstNameFilter);
+        headerRow.getCell(grid.getColumnByKey("lastName")).setComponent(lastNameFilter);
+        headerRow.getCell(grid.getColumnByKey("email")).setComponent(emailFilter);
+        headerRow.getCell(grid.getColumnByKey("phone")).setComponent(phoneFilter);
+        headerRow.getCell(grid.getColumnByKey("dateOfBirth")).setComponent(dateOfBirthFilter);
+        headerRow.getCell(grid.getColumnByKey("occupation")).setComponent(occupationFilter);
+        headerRow.getCell(grid.getColumnByKey("lastContacted")).setComponent(lastContactedFilter);
+        headerRow.getCell(grid.getColumnByKey("lastInterviewed")).setComponent(lastInterviewedFilter);
     }
 
     private void refreshGrid() {
@@ -192,6 +264,9 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 
     private void clearForm() {
         populateForm(null);
+        if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
+            editorLayoutDiv.setVisible(false);
+        }
     }
 
     private void populateForm(Panelist value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropiertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropiertiesView.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
@@ -38,12 +39,17 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
     private final String PANELISTPROPERTY_EDIT_ROUTE_TEMPLATE = "master-detail/%s/edit";
 
     private final Grid<PanelistProperty> grid = new Grid<>(PanelistProperty.class, false);
+    private Div editorLayoutDiv; // Declarado como miembro de la clase
+
+    // Campos de filtro
+    private TextField nameFilter = new TextField();
+    private TextField typeFilter = new TextField();
 
     private TextField name;
     private TextField type;
 
-    private final Button cancel = new Button("Cancel");
-    private final Button save = new Button("Save");
+    private final Button cancel = new Button("Cancelar");
+    private final Button save = new Button("Guardar");
 
     private final BeanValidationBinder<PanelistProperty> binder;
 
@@ -55,27 +61,46 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
         this.panelistPropertyService = panelistPropertyService;
         addClassNames("propierties-view");
 
-        // Create UI
-        SplitLayout splitLayout = new SplitLayout();
+        // Configurar columnas del Grid PRIMERO
+        grid.addColumn(PanelistProperty::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
+        grid.addColumn(PanelistProperty::getType).setHeader("Tipo").setKey("type").setAutoWidth(true);
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 
+        // Create UI - SplitLayout
+        SplitLayout splitLayout = new SplitLayout();
+        // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
+        editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 
-        // Configure Grid
-        grid.addColumn("name").setAutoWidth(true);
-        grid.addColumn("type").setAutoWidth(true);
-        grid.setItems(
-                query -> panelistPropertyService.list(VaadinSpringDataHelpers.toSpringPageRequest(query)).stream());
-        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+        // Configurar placeholders para filtros
+        nameFilter.setPlaceholder("Filtrar por Nombre");
+        typeFilter.setPlaceholder("Filtrar por Tipo");
+
+        // Añadir listeners para refrescar el grid
+        nameFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        typeFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+
+        // Configurar el DataProvider del Grid
+        grid.setItems(query -> {
+            String nameVal = nameFilter.getValue();
+            String typeVal = typeFilter.getValue();
+
+            return panelistPropertyService.list(
+                VaadinSpringDataHelpers.toSpringPageRequest(query),
+                nameVal,
+                typeVal
+            ).stream();
+        });
 
         // when a row is selected or deselected, populate form
         grid.asSingleSelect().addValueChangeListener(event -> {
             if (event.getValue() != null) {
+                editorLayoutDiv.setVisible(true);
                 UI.getCurrent().navigate(String.format(PANELISTPROPERTY_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
             } else {
-                clearForm();
+                clearForm(); // clearForm ahora también oculta el editor
                 UI.getCurrent().navigate(PropiertiesView.class);
             }
         });
@@ -84,7 +109,6 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
         binder = new BeanValidationBinder<>(PanelistProperty.class);
 
         // Bind fields. This is where you'd define e.g. validation rules
-
         binder.bindInstanceFields(this);
 
         cancel.addClickListener(e -> {
@@ -101,15 +125,15 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
                 panelistPropertyService.save(this.panelistProperty);
                 clearForm();
                 refreshGrid();
-                Notification.show("Data updated");
+                Notification.show("Datos actualizados");
                 UI.getCurrent().navigate(PropiertiesView.class);
             } catch (ObjectOptimisticLockingFailureException exception) {
                 Notification n = Notification.show(
-                        "Error updating the data. Somebody else has updated the record while you were making changes.");
+                        "Error al actualizar los datos. Otro usuario modificó el registro mientras usted realizaba cambios.");
                 n.setPosition(Position.MIDDLE);
                 n.addThemeVariants(NotificationVariant.LUMO_ERROR);
             } catch (ValidationException validationException) {
-                Notification.show("Failed to update the data. Check again that all values are valid");
+                Notification.show("Fallo al actualizar los datos. Verifique nuevamente que todos los valores sean válidos");
             }
         });
     }
@@ -122,19 +146,25 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
                     .get(panelistPropertyId.get());
             if (panelistPropertyFromBackend.isPresent()) {
                 populateForm(panelistPropertyFromBackend.get());
+                editorLayoutDiv.setVisible(true);
             } else {
-                Notification.show(String.format("The requested panelistProperty was not found, ID = %s",
+                Notification.show(String.format("La propiedad de panelista solicitada no fue encontrada, ID = %s",
                         panelistPropertyId.get()), 3000, Notification.Position.BOTTOM_START);
                 // when a row is selected but the data is no longer available,
                 // refresh grid
                 refreshGrid();
+                if (editorLayoutDiv != null) {
+                    editorLayoutDiv.setVisible(false);
+                }
                 event.forwardTo(PropiertiesView.class);
             }
+        } else {
+            clearForm(); // Asegurar que el editor esté oculto si no hay ID
         }
     }
 
     private void createEditorLayout(SplitLayout splitLayout) {
-        Div editorLayoutDiv = new Div();
+        editorLayoutDiv = new Div(); // Instanciar el miembro de la clase
         editorLayoutDiv.setClassName("editor-layout");
 
         Div editorDiv = new Div();
@@ -142,8 +172,8 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
         editorLayoutDiv.add(editorDiv);
 
         FormLayout formLayout = new FormLayout();
-        name = new TextField("Name");
-        type = new TextField("Type");
+        name = new TextField("Nombre");
+        type = new TextField("Tipo");
         formLayout.add(name, type);
 
         editorDiv.add(formLayout);
@@ -166,6 +196,10 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
         wrapper.setClassName("grid-wrapper");
         splitLayout.addToPrimary(wrapper);
         wrapper.add(grid);
+
+        HeaderRow headerRow = grid.appendHeaderRow();
+        headerRow.getCell(grid.getColumnByKey("name")).setComponent(nameFilter);
+        headerRow.getCell(grid.getColumnByKey("type")).setComponent(typeFilter);
     }
 
     private void refreshGrid() {
@@ -175,6 +209,9 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
 
     private void clearForm() {
         populateForm(null);
+        if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
+            editorLayoutDiv.setVisible(false);
+        }
     }
 
     private void populateForm(PanelistProperty value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
@@ -23,6 +24,7 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
 import jakarta.annotation.security.PermitAll;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.vaadin.lineawesome.LineAwesomeIconUrl;
@@ -39,13 +41,19 @@ public class SurveysView extends Div implements BeforeEnterObserver {
     private final String SURVEY_EDIT_ROUTE_TEMPLATE = "surveys/%s/edit";
 
     private final Grid<Survey> grid = new Grid<>(Survey.class, false);
+    private Div editorLayoutDiv; // Declarado como miembro de la clase
+
+    // Campos de filtro
+    private TextField nameFilter = new TextField();
+    private DatePicker initDateFilter = new DatePicker();
+    private TextField linkFilter = new TextField();
 
     private TextField name;
     private DatePicker initDate;
     private TextField link;
 
-    private final Button cancel = new Button("Cancel");
-    private final Button save = new Button("Save");
+    private final Button cancel = new Button("Cancelar");
+    private final Button save = new Button("Guardar");
 
     private final BeanValidationBinder<Survey> binder;
 
@@ -57,27 +65,51 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         this.surveyService = surveyService;
         addClassNames("surveys-view");
 
-        // Create UI
-        SplitLayout splitLayout = new SplitLayout();
+        // Configurar columnas del Grid PRIMERO
+        grid.addColumn(Survey::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
+        grid.addColumn(Survey::getInitDate).setHeader("Fecha de Inicio").setKey("initDate").setAutoWidth(true);
+        grid.addColumn(Survey::getLink).setHeader("Enlace").setKey("link").setAutoWidth(true);
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 
+        // Create UI - SplitLayout
+        SplitLayout splitLayout = new SplitLayout();
+        // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
+        editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 
-        // Configure Grid
-        grid.addColumn("name").setAutoWidth(true);
-        grid.addColumn("initDate").setAutoWidth(true);
-        grid.addColumn("link").setAutoWidth(true);
-        grid.setItems(query -> surveyService.list(VaadinSpringDataHelpers.toSpringPageRequest(query)).stream());
-        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+        // Configurar placeholders para filtros
+        nameFilter.setPlaceholder("Filtrar por Nombre");
+        initDateFilter.setPlaceholder("Filtrar por Fecha de Inicio");
+        linkFilter.setPlaceholder("Filtrar por Enlace");
+
+        // Añadir listeners para refrescar el grid
+        nameFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        initDateFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+        linkFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
+
+        // Configurar el DataProvider del Grid
+        grid.setItems(query -> {
+            String nameVal = nameFilter.getValue();
+            LocalDate initDateVal = initDateFilter.getValue();
+            String linkVal = linkFilter.getValue();
+
+            return surveyService.list(
+                VaadinSpringDataHelpers.toSpringPageRequest(query),
+                nameVal,
+                initDateVal,
+                linkVal
+            ).stream();
+        });
 
         // when a row is selected or deselected, populate form
         grid.asSingleSelect().addValueChangeListener(event -> {
             if (event.getValue() != null) {
+                editorLayoutDiv.setVisible(true);
                 UI.getCurrent().navigate(String.format(SURVEY_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
             } else {
-                clearForm();
+                clearForm(); // clearForm ahora también oculta el editor
                 UI.getCurrent().navigate(SurveysView.class);
             }
         });
@@ -86,7 +118,6 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         binder = new BeanValidationBinder<>(Survey.class);
 
         // Bind fields. This is where you'd define e.g. validation rules
-
         binder.bindInstanceFields(this);
 
         cancel.addClickListener(e -> {
@@ -103,15 +134,15 @@ public class SurveysView extends Div implements BeforeEnterObserver {
                 surveyService.save(this.survey);
                 clearForm();
                 refreshGrid();
-                Notification.show("Data updated");
+                Notification.show("Datos actualizados");
                 UI.getCurrent().navigate(SurveysView.class);
             } catch (ObjectOptimisticLockingFailureException exception) {
                 Notification n = Notification.show(
-                        "Error updating the data. Somebody else has updated the record while you were making changes.");
+                        "Error al actualizar los datos. Otro usuario modificó el registro mientras usted realizaba cambios.");
                 n.setPosition(Position.MIDDLE);
                 n.addThemeVariants(NotificationVariant.LUMO_ERROR);
             } catch (ValidationException validationException) {
-                Notification.show("Failed to update the data. Check again that all values are valid");
+                Notification.show("Fallo al actualizar los datos. Verifique nuevamente que todos los valores sean válidos");
             }
         });
     }
@@ -123,19 +154,25 @@ public class SurveysView extends Div implements BeforeEnterObserver {
             Optional<Survey> surveyFromBackend = surveyService.get(surveyId.get());
             if (surveyFromBackend.isPresent()) {
                 populateForm(surveyFromBackend.get());
+                editorLayoutDiv.setVisible(true);
             } else {
-                Notification.show(String.format("The requested survey was not found, ID = %s", surveyId.get()), 3000,
+                Notification.show(String.format("La encuesta solicitada no fue encontrada, ID = %s", surveyId.get()), 3000,
                         Notification.Position.BOTTOM_START);
                 // when a row is selected but the data is no longer available,
                 // refresh grid
                 refreshGrid();
+                if (editorLayoutDiv != null) {
+                    editorLayoutDiv.setVisible(false);
+                }
                 event.forwardTo(SurveysView.class);
             }
+        } else {
+            clearForm(); // Asegurar que el editor esté oculto si no hay ID
         }
     }
 
     private void createEditorLayout(SplitLayout splitLayout) {
-        Div editorLayoutDiv = new Div();
+        editorLayoutDiv = new Div(); // Instanciar el miembro de la clase
         editorLayoutDiv.setClassName("editor-layout");
 
         Div editorDiv = new Div();
@@ -143,9 +180,9 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         editorLayoutDiv.add(editorDiv);
 
         FormLayout formLayout = new FormLayout();
-        name = new TextField("Name");
-        initDate = new DatePicker("Init Date");
-        link = new TextField("Link");
+        name = new TextField("Nombre");
+        initDate = new DatePicker("Fecha de Inicio");
+        link = new TextField("Enlace");
         formLayout.add(name, initDate, link);
 
         editorDiv.add(formLayout);
@@ -168,6 +205,11 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         wrapper.setClassName("grid-wrapper");
         splitLayout.addToPrimary(wrapper);
         wrapper.add(grid);
+
+        HeaderRow headerRow = grid.appendHeaderRow();
+        headerRow.getCell(grid.getColumnByKey("name")).setComponent(nameFilter);
+        headerRow.getCell(grid.getColumnByKey("initDate")).setComponent(initDateFilter);
+        headerRow.getCell(grid.getColumnByKey("link")).setComponent(linkFilter);
     }
 
     private void refreshGrid() {
@@ -177,6 +219,9 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 
     private void clearForm() {
         populateForm(null);
+        if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
+            editorLayoutDiv.setVisible(false);
+        }
     }
 
     private void populateForm(Survey value) {


### PR DESCRIPTION
I've modified all the main views (Panels, Panelists, Properties, Surveys, Incentives, Users) so that the edit panel is not displayed when the view is initially loaded.

The edit panel will now only become visible when:
1. You select a row in the table (Grid).
2. You navigate directly to a URL that specifies editing an existing item (e.g., /panels/1/edit).

The implemented logic includes:
- Making the editor's Div (`editorLayoutDiv`) a class member.
- Setting `editorLayoutDiv.setVisible(false)` by default in the constructor.
- Controlling visibility in the Grid's selection listeners.
- Ensuring that `clearForm()` hides the editor.
- Displaying the editor in `beforeEnter()` if an item is loaded for editing from the URL.