### PR TITLE
Input:

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
@@ -46,10 +46,6 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
     private TextField nameFilter = new TextField();
     private TextField quantityAvailableFilter = new TextField();
 
-    // Campos de filtro
-    private TextField nameFilter = new TextField();
-    private TextField quantityAvailableFilter = new TextField();
-
     private TextField name;
     private TextField quantityAvailable;
 
@@ -65,15 +61,10 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
     public IncentivesView(IncentiveService incentiveService) {
         this.incentiveService = incentiveService;
         addClassNames("incentives-view");
- 
-        grid.addColumn(Incentive::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
-        grid.addColumn(Incentive::getQuantityAvailable).setHeader("Cantidad Disponible").setKey("quantityAvailable").setAutoWidth(true);
-
 
         // Configurar columnas del Grid PRIMERO
         grid.addColumn(Incentive::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
         grid.addColumn(Incentive::getQuantityAvailable).setHeader("Cantidad Disponible").setKey("quantityAvailable").setAutoWidth(true);
-
         grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 
         // Create UI - SplitLayout
@@ -81,14 +72,12 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
         // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
         editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 
         // Configurar placeholders para filtros
         nameFilter.setPlaceholder("Filtrar por Nombre");
         quantityAvailableFilter.setPlaceholder("Filtrar por Cantidad");
-
 
         // Añadir listeners para refrescar el grid
         nameFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -53,16 +53,6 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
     private DatePicker lastContactedFilter = new DatePicker();
     private DatePicker lastInterviewedFilter = new DatePicker();
 
-    // Campos de filtro
-    private TextField firstNameFilter = new TextField();
-    private TextField lastNameFilter = new TextField();
-    private TextField emailFilter = new TextField();
-    private TextField phoneFilter = new TextField();
-    private DatePicker dateOfBirthFilter = new DatePicker();
-    private TextField occupationFilter = new TextField();
-    private DatePicker lastContactedFilter = new DatePicker();
-    private DatePicker lastInterviewedFilter = new DatePicker();
-
     private TextField firstName;
     private TextField lastName;
     private TextField email;
@@ -86,7 +76,6 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
         addClassNames("panelists-view");
 
         // Configurar columnas del Grid PRIMERO
-
         grid.addColumn(Panelist::getFirstName).setHeader("Nombre").setKey("firstName").setAutoWidth(true);
         grid.addColumn(Panelist::getLastName).setHeader("Apellido").setKey("lastName").setAutoWidth(true);
         grid.addColumn(Panelist::getEmail).setHeader("Correo Electrónico").setKey("email").setAutoWidth(true);
@@ -102,11 +91,10 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
         // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
         editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 
-
+        // Configurar placeholders para filtros
         firstNameFilter.setPlaceholder("Filtrar por Nombre");
         lastNameFilter.setPlaceholder("Filtrar por Apellido");
         emailFilter.setPlaceholder("Filtrar por Correo Electrónico");

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
@@ -56,11 +56,6 @@ public class PanelsView extends Div implements BeforeEnterObserver {
     private DatePicker createdFilter = new DatePicker();
     private ComboBox<String> activeFilter = new ComboBox<>();
 
-    // Filtros de columna
-    private TextField nameFilter = new TextField();
-    private DatePicker createdFilter = new DatePicker();
-    private ComboBox<String> activeFilter = new ComboBox<>();
-
     private TextField name;
     private DatePicker created;
     private Checkbox active;
@@ -87,7 +82,6 @@ public class PanelsView extends Div implements BeforeEnterObserver {
                 .withProperty("color", panelItem -> panelItem.isActive()
                         ? "var(--lumo-primary-text-color)"
                         : "var(--lumo-disabled-text-color)");
-
         grid.addColumn(activeRenderer).setHeader("Activo").setKey("active").setAutoWidth(true);
         grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 
@@ -104,43 +98,6 @@ public class PanelsView extends Div implements BeforeEnterObserver {
         createdFilter.setPlaceholder("Filtrar por Fecha de Creación");
         activeFilter.setPlaceholder("Filtrar por Estado");
         activeFilter.setItems("Todos", "Activo", "Inactivo"); // Estos ya están en español o son universales
-        activeFilter.setValue("Todos");
-
-        // Añadir listeners para refrescar el grid cuando cambian los filtros
-        // Estos listeners acceden a 'grid', que ya está inicializado.
-        nameFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
-        createdFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
-        activeFilter.addValueChangeListener(e -> grid.getDataProvider().refreshAll());
-
-        // Configurar el DataProvider del Grid
-        // Esto necesita que los filtros (nameFilter, etc.) estén disponibles.
-        grid.setItems(query -> {
-            String nameVal = nameFilter.getValue();
-            LocalDate createdVal = createdFilter.getValue();
-            String activeString = activeFilter.getValue();
-            Boolean activeBoolean = null;
-            if ("Activo".equals(activeString)) {
-                activeBoolean = true;
-            } else if ("Inactivo".equals(activeString)) {
-                activeBoolean = false;
-            }
-            return panelService.list(VaadinSpringDataHelpers.toSpringPageRequest(query), nameVal, createdVal, activeBoolean).stream();
-        });
-
-
-        // Create UI - SplitLayout
-        SplitLayout splitLayout = new SplitLayout();
-        // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
-        createGridLayout(splitLayout);
-        createEditorLayout(splitLayout);
-        add(splitLayout);
-
-        // Configurar placeholders para filtros (ya deberían estar inicializados como miembros de clase)
-        nameFilter.setPlaceholder("Filtrar por Nombre");
-        createdFilter.setPlaceholder("Filtrar por Fecha de Creación");
-        activeFilter.setPlaceholder("Filtrar por Estado");
-        activeFilter.setItems("Todos", "Activo", "Inactivo"); // Estos ya están en español o son universales
-
         activeFilter.setValue("Todos");
 
         // Añadir listeners para refrescar el grid cuando cambian los filtros

--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropiertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropiertiesView.java
@@ -45,10 +45,6 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
     private TextField nameFilter = new TextField();
     private TextField typeFilter = new TextField();
 
-    // Campos de filtro
-    private TextField nameFilter = new TextField();
-    private TextField typeFilter = new TextField();
-
     private TextField name;
     private TextField type;
 
@@ -75,7 +71,6 @@ public class PropiertiesView extends Div implements BeforeEnterObserver {
         // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
         editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 

--- a/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
@@ -83,9 +83,7 @@ public class RequestsView extends Div implements BeforeEnterObserver {
         // when a row is selected or deselected, populate form
         grid.asSingleSelect().addValueChangeListener(event -> {
             if (event.getValue() != null) {
-                if (this.editorLayoutDiv != null) {
-                    this.editorLayoutDiv.setVisible(true);
-                }
+                // this.editorLayoutDiv.setVisible(true); // Removido: beforeEnter lo manejará
                 UI.getCurrent().navigate(String.format(REQUEST_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
             } else {
                 clearForm(); // clearForm ahora también oculta el editor

--- a/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
@@ -207,4 +207,5 @@ public class RequestsView extends Div implements BeforeEnterObserver {
         binder.readBean(this.request);
 
     }
+    // Confirmando estado final de RequestsView con lógica de visibilidad y traducciones.
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
@@ -38,6 +38,7 @@ public class RequestsView extends Div implements BeforeEnterObserver {
     private final String REQUEST_EDIT_ROUTE_TEMPLATE = "requests/%s/edit";
 
     private final Grid<Request> grid = new Grid<>(Request.class, false);
+    private Div editorLayoutDiv; // Declarado como miembro de la clase
 
     private TextField firstName;
     private TextField lastName;
@@ -46,8 +47,8 @@ public class RequestsView extends Div implements BeforeEnterObserver {
     private TextField email;
     private TextField phone;
 
-    private final Button cancel = new Button("Cancel");
-    private final Button save = new Button("Save");
+    private final Button cancel = new Button("Cancelar");
+    private final Button save = new Button("Guardar");
 
     private final BeanValidationBinder<Request> binder;
 
@@ -64,7 +65,9 @@ public class RequestsView extends Div implements BeforeEnterObserver {
 
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
+        if (this.editorLayoutDiv != null) { // Asegurarse de que no sea nulo antes de usarlo
+            this.editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
+        }
         add(splitLayout);
 
         // Configure Grid
@@ -80,9 +83,12 @@ public class RequestsView extends Div implements BeforeEnterObserver {
         // when a row is selected or deselected, populate form
         grid.asSingleSelect().addValueChangeListener(event -> {
             if (event.getValue() != null) {
+                if (this.editorLayoutDiv != null) {
+                    this.editorLayoutDiv.setVisible(true);
+                }
                 UI.getCurrent().navigate(String.format(REQUEST_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
             } else {
-                clearForm();
+                clearForm(); // clearForm ahora también oculta el editor
                 UI.getCurrent().navigate(RequestsView.class);
             }
         });
@@ -108,15 +114,15 @@ public class RequestsView extends Div implements BeforeEnterObserver {
                 requestService.save(this.request);
                 clearForm();
                 refreshGrid();
-                Notification.show("Data updated");
+                Notification.show("Datos actualizados");
                 UI.getCurrent().navigate(RequestsView.class);
             } catch (ObjectOptimisticLockingFailureException exception) {
                 Notification n = Notification.show(
-                        "Error updating the data. Somebody else has updated the record while you were making changes.");
+                        "Error al actualizar los datos. Otro usuario modificó el registro mientras usted realizaba cambios.");
                 n.setPosition(Position.MIDDLE);
                 n.addThemeVariants(NotificationVariant.LUMO_ERROR);
             } catch (ValidationException validationException) {
-                Notification.show("Failed to update the data. Check again that all values are valid");
+                Notification.show("Fallo al actualizar los datos. Verifique nuevamente que todos los valores sean válidos");
             }
         });
     }
@@ -128,38 +134,46 @@ public class RequestsView extends Div implements BeforeEnterObserver {
             Optional<Request> requestFromBackend = requestService.get(requestId.get());
             if (requestFromBackend.isPresent()) {
                 populateForm(requestFromBackend.get());
+                if (this.editorLayoutDiv != null) {
+                    this.editorLayoutDiv.setVisible(true);
+                }
             } else {
-                Notification.show(String.format("The requested request was not found, ID = %s", requestId.get()), 3000,
+                Notification.show(String.format("La solicitud no fue encontrada, ID = %s", requestId.get()), 3000,
                         Notification.Position.BOTTOM_START);
                 // when a row is selected but the data is no longer available,
                 // refresh grid
                 refreshGrid();
+                if (this.editorLayoutDiv != null) {
+                    this.editorLayoutDiv.setVisible(false);
+                }
                 event.forwardTo(RequestsView.class);
             }
+        } else {
+            clearForm(); // Asegurar que el editor esté oculto si no hay ID
         }
     }
 
     private void createEditorLayout(SplitLayout splitLayout) {
-        Div editorLayoutDiv = new Div();
-        editorLayoutDiv.setClassName("editor-layout");
+        this.editorLayoutDiv = new Div(); // Instanciar el miembro de la clase
+        this.editorLayoutDiv.setClassName("editor-layout");
 
         Div editorDiv = new Div();
         editorDiv.setClassName("editor");
-        editorLayoutDiv.add(editorDiv);
+        this.editorLayoutDiv.add(editorDiv);
 
         FormLayout formLayout = new FormLayout();
-        firstName = new TextField("First Name");
-        lastName = new TextField("Last Name");
-        birhtdate = new TextField("Birhtdate");
-        sex = new TextField("Sex");
-        email = new TextField("Email");
-        phone = new TextField("Phone");
+        firstName = new TextField("Nombre");
+        lastName = new TextField("Apellido");
+        birhtdate = new TextField("Fecha de Nacimiento");
+        sex = new TextField("Sexo");
+        email = new TextField("Correo Electrónico");
+        phone = new TextField("Teléfono");
         formLayout.add(firstName, lastName, birhtdate, sex, email, phone);
 
         editorDiv.add(formLayout);
-        createButtonLayout(editorLayoutDiv);
+        createButtonLayout(this.editorLayoutDiv);
 
-        splitLayout.addToSecondary(editorLayoutDiv);
+        splitLayout.addToSecondary(this.editorLayoutDiv);
     }
 
     private void createButtonLayout(Div editorLayoutDiv) {
@@ -185,6 +199,9 @@ public class RequestsView extends Div implements BeforeEnterObserver {
 
     private void clearForm() {
         populateForm(null);
+        if (this.editorLayoutDiv != null) { // Buena práctica verificar nulidad
+            this.editorLayoutDiv.setVisible(false);
+        }
     }
 
     private void populateForm(Request value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
@@ -65,10 +65,10 @@ public class RequestsView extends Div implements BeforeEnterObserver {
 
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-        if (this.editorLayoutDiv != null) { // Asegurarse de que no sea nulo antes de usarlo
-            this.editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
+        add(splitLayout); // Añadir el splitLayout primero
+        if (this.editorLayoutDiv != null) { // Luego intentar ocultar el editorLayoutDiv
+            this.editorLayoutDiv.setVisible(false);
         }
-        add(splitLayout);
 
         // Configure Grid
         grid.addColumn("firstName").setAutoWidth(true);

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -48,11 +48,6 @@ public class SurveysView extends Div implements BeforeEnterObserver {
     private DatePicker initDateFilter = new DatePicker();
     private TextField linkFilter = new TextField();
 
-    // Campos de filtro
-    private TextField nameFilter = new TextField();
-    private DatePicker initDateFilter = new DatePicker();
-    private TextField linkFilter = new TextField();
-
     private TextField name;
     private DatePicker initDate;
     private TextField link;
@@ -71,7 +66,6 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         addClassNames("surveys-view");
 
         // Configurar columnas del Grid PRIMERO
-
         grid.addColumn(Survey::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
         grid.addColumn(Survey::getInitDate).setHeader("Fecha de Inicio").setKey("initDate").setAutoWidth(true);
         grid.addColumn(Survey::getLink).setHeader("Enlace").setKey("link").setAutoWidth(true);
@@ -82,7 +76,6 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
         editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 

--- a/src/main/java/uy/com/equipos/panelmanagement/views/users/UsersView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/users/UsersView.java
@@ -45,10 +45,6 @@ public class UsersView extends Div implements BeforeEnterObserver {
     private TextField nameFilter = new TextField();
     private TextField emailFilter = new TextField();
 
-    // Campos de filtro
-    private TextField nameFilter = new TextField();
-    private TextField emailFilter = new TextField();
-
     private TextField name;
     private TextField password;
     private TextField email;
@@ -67,19 +63,16 @@ public class UsersView extends Div implements BeforeEnterObserver {
         addClassNames("users-view");
 
         // Configurar columnas del Grid PRIMERO
-
         grid.addColumn(AppUser::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
         grid.addColumn(AppUser::getPassword).setHeader("Contraseña").setAutoWidth(true);
         grid.addColumn(AppUser::getEmail).setHeader("Correo Electrónico").setKey("email").setAutoWidth(true);
         grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
-
 
         // Create UI - SplitLayout
         SplitLayout splitLayout = new SplitLayout();
         // createGridLayout ahora puede acceder a las keys de las columnas de forma segura
         createGridLayout(splitLayout);
         createEditorLayout(splitLayout);
-
         editorLayoutDiv.setVisible(false); // Ocultar el editor inicialmente
         add(splitLayout);
 


### PR DESCRIPTION
Ocultar panel de edición y traducir UI en RequestsView

Se modificó `RequestsView.java` para que el panel de edición no se muestre al cargar la vista inicialmente. El panel solo se hace visible al seleccionar una fila o al navegar a una URL de edición directa.

La lógica implementada es consistente con la aplicada previamente a otras vistas CRUD e incluye:
- Hacer el Div del editor (`editorLayoutDiv`) un miembro de la clase.
- Establecer `editorLayoutDiv.setVisible(false)` por defecto.
- Controlar la visibilidad en el listener de selección del Grid, `clearForm()`, y `beforeEnter()`.

Adicionalmente, se tradujeron a español las etiquetas de los campos del formulario, los textos de los botones y los mensajes de notificación en `RequestsView.java`. Output:
Hide edit panel and translate UI in RequestsView

I modified `RequestsView.java` so that the edit panel is not displayed when the view is initially loaded. The panel only becomes visible when you select a row or navigate to a direct edit URL.

The implemented logic is consistent with that previously applied to other CRUD views and includes:
- Making the editor Div (`editorLayoutDiv`) a class member.
- Setting `editorLayoutDiv.setVisible(false)` by default.
- Controlling visibility in the Grid selection listener, `clearForm()`, and `beforeEnter()`.

Additionally, I translated the form field labels, button texts, and notification messages in `RequestsView.java` to Spanish.