### PR TITLE
Fix: Handle null 'quantityAvailable' in IncentivesView binding

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
@@ -141,7 +141,9 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
 		binder = new BeanValidationBinder<>(Incentive.class);
 
 		// Bind fields. This is where you'd define e.g. validation rules
-		binder.forField(quantityAvailable).withConverter(new StringToIntegerConverter("Solo se permiten números"))
+		binder.forField(quantityAvailable)
+				.withConverter(new StringToIntegerConverter("Solo se permiten números"))
+				.withNullRepresentation("")
 				.bind("quantityAvailable");
 
 		binder.bindInstanceFields(this);


### PR DESCRIPTION
The 'Cantidad Disponible' TextField in IncentivesView would throw a BindingException if the underlying 'quantityAvailable' field of an Incentive object was null. This typically occurred when clearing the form or loading an incentive with no quantity specified.

The root cause was a NullPointerException within Vaadin's data binding logic because the TextField was not configured to handle null values.

This commit fixes the issue by adding `.withNullRepresentation("")` to the binder for the 'quantityAvailable' field. This ensures that a null value in the bean is represented as an empty string in the TextField, and an empty string in the TextField is converted back to null in the bean, thus preventing the exception.