### PR TITLE
Fix: Correct StringToIntegerConverter for null 'quantityAvailable'

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
@@ -142,8 +142,7 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
 
 		// Bind fields. This is where you'd define e.g. validation rules
 		binder.forField(quantityAvailable)
-				.withConverter(new StringToIntegerConverter("Solo se permiten números"))
-				.withNullRepresentation("")
+				.withConverter(new StringToIntegerConverter(null, "Solo se permiten números"))
 				.bind("quantityAvailable");
 
 		binder.bindInstanceFields(this);


### PR DESCRIPTION
This commit corrects the data binding for the 'Cantidad Disponible' (quantityAvailable) TextField in IncentivesView.

The previous attempt to fix a NullPointerException by using `.withNullRepresentation("")` was incorrect, as this method expects an argument of the model's type (Integer), not the presentation type (String), leading to a compilation error.

The correct approach, implemented here, is to configure the StringToIntegerConverter itself to handle empty input. The converter is now instantiated as `new StringToIntegerConverter(null, "Solo se permiten números")`. This ensures that an empty string in the TextField is converted to a null Integer for the bean property, and vice-versa, resolving the original BindingException.