### PR TITLE
Fix: Corrige error de SQL en la generación de IDs para MariaDB

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/AbstractEntity.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/AbstractEntity.java
@@ -11,9 +11,7 @@ import jakarta.persistence.Version;
 public abstract class AbstractEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "idgenerator")
-    // The initial value is to account for data.sql demo data ids
-    @SequenceGenerator(name = "idgenerator", initialValue = 1000)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Version

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,4 @@ spring.jpa.hibernate.ddl-auto = update
 vaadin.allowed-packages = com.vaadin,org.vaadin,com.flowingcode,uy.com.equipos.panelmanagement
 spring.jpa.defer-datasource-initialization = true
 spring.sql.init.mode = always
+spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect


### PR DESCRIPTION
Resuelve un error `org.springframework.dao.InvalidDataAccessResourceUsageException` causado por una sintaxis SQL incorrecta (`select next value for idgenerator`) al intentar guardar entidades. Este error ocurría porque la estrategia de generación de IDs estaba configurada como `GenerationType.SEQUENCE` con un `@SequenceGenerator`, lo cual no es directamente compatible con la implementación de secuencias en MariaDB/MySQL de la forma que Hibernate lo esperaba por defecto.

Cambios realizados:
1.  Modifiqué la estrategia de generación de IDs en `AbstractEntity.java` de `GenerationType.SEQUENCE` a `GenerationType.IDENTITY`. Esto utiliza la funcionalidad `AUTO_INCREMENT` nativa de MariaDB/MySQL.
2.  Eliminé la anotación `@SequenceGenerator` correspondiente, ya que no es necesaria con `GenerationType.IDENTITY`.
3.  Especificé explícitamente el dialecto de MariaDB en `application.properties` añadiendo la línea `spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect`. Esto asegura que Hibernate genere SQL compatible.

Te recomiendo revisar y ajustar manualmente los valores de `AUTO_INCREMENT` en las tablas de la base de datos después de que `data.sql` se ejecute, especialmente si dependías del `initialValue` del `@SequenceGenerator` anterior para la numeración de los IDs.