### PR TITLE
Feature: Add delete buttons and fix initialization

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
@@ -70,6 +70,11 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
 		this.incentiveService = incentiveService;
 		addClassNames("incentives-view");
 
+		// Initialize deleteButton EARLIER
+		deleteButton = new Button("Eliminar");
+		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
+		deleteButton.addClickListener(e -> onDeleteClicked());
+
 		// Configurar columnas del Grid PRIMERO
 		grid.addColumn(Incentive::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
 		grid.addColumn(Incentive::getQuantityAvailable).setHeader("Cantidad Disponible").setKey("quantityAvailable")
@@ -149,10 +154,6 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
 				.bind("quantityAvailable");
 
 		binder.bindInstanceFields(this);
-
-		deleteButton = new Button("Eliminar");
-		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
-		deleteButton.addClickListener(e -> onDeleteClicked());
 
 		cancel.addClickListener(e -> {
 			clearForm();
@@ -249,13 +250,6 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
-	}
-
-	private void clearForm() {
-		populateForm(null);
-		if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
-			editorLayoutDiv.setVisible(false);
-		}
 	}
 
 	private void populateForm(Incentive value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -83,6 +83,11 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 		this.panelistService = panelistService;
 		addClassNames("panelists-view");
 
+		// Initialize deleteButton EARLIER
+		deleteButton = new Button("Eliminar");
+		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
+		deleteButton.addClickListener(e -> onDeleteClicked());
+
 		// Configurar columnas del Grid PRIMERO
 		grid.addColumn(Panelist::getFirstName).setHeader("Nombre").setKey("firstName").setAutoWidth(true);
 		grid.addColumn(Panelist::getLastName).setHeader("Apellido").setKey("lastName").setAutoWidth(true);
@@ -181,10 +186,6 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 
 		// Bind fields. This is where you'd define e.g. validation rules
 		binder.bindInstanceFields(this);
-
-		deleteButton = new Button("Eliminar");
-		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
-		deleteButton.addClickListener(e -> onDeleteClicked());
 
 		cancel.addClickListener(e -> {
 			clearForm();
@@ -292,13 +293,6 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
-	}
-
-	private void clearForm() {
-		populateForm(null);
-		if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
-			editorLayoutDiv.setVisible(false);
-		}
 	}
 
 	private void populateForm(Panelist value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
@@ -81,6 +81,11 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 		this.panelService = panelService;
 		addClassNames("panels-view");
 
+		// Initialize deleteButton EARLIER
+		deleteButton = new Button("Eliminar");
+		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
+		deleteButton.addClickListener(e -> onDeleteClicked());
+
 		// Configurar columnas del Grid PRIMERO
 		grid.addColumn(Panel::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
 		grid.addColumn(Panel::getCreated).setHeader("Creado").setKey("created").setAutoWidth(true);
@@ -171,10 +176,6 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 
 		// Bind fields. This is where you'd define e.g. validation rules
 		binder.bindInstanceFields(this);
-
-		deleteButton = new Button("Eliminar");
-		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
-		deleteButton.addClickListener(e -> onDeleteClicked());
 
 		cancel.addClickListener(e -> {
 			clearForm();
@@ -271,11 +272,6 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
-	}
-
-	private void clearForm() {
-		populateForm(null);
-		editorLayoutDiv.setVisible(false); // Ocultar el editor al limpiar el formulario
 	}
 
 	private void populateForm(Panel value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
@@ -69,6 +69,11 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
 		this.panelistPropertyService = panelistPropertyService;
 		addClassNames("propierties-view");
 
+		// Initialize deleteButton EARLIER
+		deleteButton = new Button("Eliminar");
+		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
+		deleteButton.addClickListener(e -> onDeleteClicked());
+
 		// Configurar columnas del Grid PRIMERO
 		grid.addColumn(PanelistProperty::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
 		grid.addColumn(PanelistProperty::getType).setHeader("Tipo").setKey("type").setAutoWidth(true);
@@ -140,10 +145,6 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
 
 		// Bind fields. This is where you'd define e.g. validation rules
 		binder.bindInstanceFields(this);
-
-		deleteButton = new Button("Eliminar");
-		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
-		deleteButton.addClickListener(e -> onDeleteClicked());
 
 		cancel.addClickListener(e -> {
 			clearForm();
@@ -240,13 +241,6 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
-	}
-
-	private void clearForm() {
-		populateForm(null);
-		if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
-			editorLayoutDiv.setVisible(false);
-		}
 	}
 
 	private void populateForm(PanelistProperty value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/requests/RequestsView.java
@@ -68,6 +68,11 @@ public class RequestsView extends Div implements BeforeEnterObserver {
 		this.requestService = requestService;
 		addClassNames("requests-view");
 
+		// Initialize deleteButton EARLIER
+		deleteButton = new Button("Eliminar");
+		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
+		deleteButton.addClickListener(e -> onDeleteClicked());
+
 		// Create UI
 		SplitLayout splitLayout = new SplitLayout();
 
@@ -126,10 +131,6 @@ public class RequestsView extends Div implements BeforeEnterObserver {
 		// Bind fields. This is where you'd define e.g. validation rules
 
 		binder.bindInstanceFields(this);
-
-		deleteButton = new Button("Eliminar");
-		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
-		deleteButton.addClickListener(e -> onDeleteClicked());
 
 		cancel.addClickListener(e -> {
 			clearForm();
@@ -227,13 +228,6 @@ public class RequestsView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
-	}
-
-	private void clearForm() {
-		populateForm(null);
-		if (this.editorLayoutDiv != null) { // Buena práctica verificar nulidad
-			this.editorLayoutDiv.setVisible(false);
-		}
 	}
 
 	private void populateForm(Request value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -73,6 +73,11 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 		this.surveyService = surveyService;
 		addClassNames("surveys-view");
 
+		// Initialize deleteButton EARLIER
+		deleteButton = new Button("Eliminar");
+		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
+		deleteButton.addClickListener(e -> onDeleteClicked());
+
 		// Configurar columnas del Grid PRIMERO
 		grid.addColumn(Survey::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
 		grid.addColumn(Survey::getInitDate).setHeader("Fecha de Inicio").setKey("initDate").setAutoWidth(true);
@@ -148,10 +153,6 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 
 		// Bind fields. This is where you'd define e.g. validation rules
 		binder.bindInstanceFields(this);
-
-		deleteButton = new Button("Eliminar");
-		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
-		deleteButton.addClickListener(e -> onDeleteClicked());
 
 		cancel.addClickListener(e -> {
 			clearForm();
@@ -249,13 +250,6 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
-	}
-
-	private void clearForm() {
-		populateForm(null);
-		if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
-			editorLayoutDiv.setVisible(false);
-		}
 	}
 
 	private void populateForm(Survey value) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/users/UsersView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/users/UsersView.java
@@ -70,6 +70,11 @@ public class UsersView extends Div implements BeforeEnterObserver {
 		this.appUserService = appUserService;
 		addClassNames("users-view");
 
+		// Initialize deleteButton EARLIER
+		deleteButton = new Button("Eliminar");
+		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
+		deleteButton.addClickListener(e -> onDeleteClicked());
+
 		// Configurar columnas del Grid PRIMERO
 		grid.addColumn(AppUser::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
 		grid.addColumn(AppUser::getPassword).setHeader("Contraseña").setAutoWidth(true);
@@ -140,10 +145,6 @@ public class UsersView extends Div implements BeforeEnterObserver {
 
 		// Bind fields. This is where you'd define e.g. validation rules
 		binder.bindInstanceFields(this);
-
-		deleteButton = new Button("Eliminar");
-		deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
-		deleteButton.addClickListener(e -> onDeleteClicked());
 
 		cancel.addClickListener(e -> {
 			clearForm();
@@ -240,13 +241,6 @@ public class UsersView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
-	}
-
-	private void clearForm() {
-		populateForm(null);
-		if (editorLayoutDiv != null) { // Buena práctica verificar nulidad
-			editorLayoutDiv.setVisible(false);
-		}
 	}
 
 	private void populateForm(AppUser value) {


### PR DESCRIPTION
Deletion functionality (button, confirmation dialog, service logic, and UI/error handling) is implemented in the following edit views:
- IncentivesView
- PanelsView
- UsersView (for AppUser)
- PanelistsView
- PropertiesView (for PanelistProperty)
- RequestsView
- SurveysView

Additionally, NullPointerException errors that arose during the creation of these views are corrected. These errors were due to the late initialization of the `deleteButton` (after being added to the layout) and the presence of duplicate `clearForm()` methods.

The corrections applied to all mentioned views include:
- Moving the instantiation and configuration of the `deleteButton` to a point in the constructor before its use in `createButtonLayout()`.
- Removing duplicate declarations of the `clearForm()` method, keeping the version that manages the enabled/disabled state of the `deleteButton`.

With these changes, it is expected that all affected views will initialize correctly and that the deletion functionality will operate as intended. The corresponding services already had the necessary `delete()` methods.