### PR TITLE
Fix: Evitar NullPointerException en IncentivesView al crear nuevo inc…

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/incentives/IncentivesView.java
@@ -254,6 +254,11 @@ public class IncentivesView extends Div implements BeforeEnterObserver {
 
 	private void populateForm(Incentive value) {
 		this.incentive = value;
+		if (this.incentive != null && this.incentive.getId() == null) {
+			// Para un nuevo incentivo, inicializar quantityAvailable a 0
+			// para evitar el error de binding con el TextField.
+			this.incentive.setQuantityAvailable(0);
+		}
 		binder.readBean(this.incentive);
 
 		if (deleteButton != null) { // Check if button is initialized


### PR DESCRIPTION
…entivo

El error ocurría al presionar "Nuevo Incentivo" debido a que el BeanValidationBinder intentaba leer la propiedad 'quantityAvailable' de un objeto Incentive recién instanciado. Si esta propiedad era null (como es el caso por defecto para un Integer), y el TextField asociado no estaba configurado para manejar una representación nula explícitamente al leer desde el bean, se lanzaba una excepción.

La solución consiste en modificar el método `populateForm` en `IncentivesView.java`. Ahora, si se está poblando el formulario para un incentivo nuevo (identificado por tener un ID nulo), la propiedad `quantityAvailable` del objeto Incentive se establece explícitamente a 0 antes de que el `binder.readBean()` sea invocado.

Esto asegura que el binder siempre lea un valor no nulo para este campo al crear un nuevo incentivo, evitando así la excepción y estableciendo un valor predeterminado razonable ("0") en el campo "Cantidad Disponible" del formulario.