### PR TITLE
feat: Vincular Panelist y PanelistProperty con relación N:N

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
@@ -1,8 +1,14 @@
 package uy.com.equipos.panelmanagement.data;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.validation.constraints.Email;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 public class Panelist extends AbstractEntity {
@@ -66,4 +72,19 @@ public class Panelist extends AbstractEntity {
         this.lastInterviewed = lastInterviewed;
     }
 
+    @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+    @JoinTable(
+        name = "panelist_panelist_property",
+        joinColumns = @JoinColumn(name = "panelist_id"),
+        inverseJoinColumns = @JoinColumn(name = "panelist_property_id")
+    )
+    private Set<PanelistProperty> properties = new HashSet<>();
+
+    public Set<PanelistProperty> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Set<PanelistProperty> properties) {
+        this.properties = properties;
+    }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistProperty.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistProperty.java
@@ -1,6 +1,9 @@
 package uy.com.equipos.panelmanagement.data;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToMany;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 public class PanelistProperty extends AbstractEntity {
@@ -21,4 +24,14 @@ public class PanelistProperty extends AbstractEntity {
         this.type = type;
     }
 
+    @ManyToMany(mappedBy = "properties")
+    private Set<Panelist> panelists = new HashSet<>();
+
+    public Set<Panelist> getPanelists() {
+        return panelists;
+    }
+
+    public void setPanelists(Set<Panelist> panelists) {
+        this.panelists = panelists;
+    }
 }


### PR DESCRIPTION
Se establece una relación de muchos a muchos (N:N) entre las entidades Panelist y PanelistProperty.

Cambios realizados:
- Se modificó la entidad `Panelist` para incluir una colección de `PanelistProperty` anotada con `@ManyToMany` y `@JoinTable` para definir la tabla intermedia `panelist_panelist_property`.
- Se modificó la entidad `PanelistProperty` para incluir la referencia inversa a la colección de `Panelist` (opcional, pero buena práctica).
- Se actualizó la vista `PanelistsView` para permitir la selección múltiple de `PanelistProperty` al editar un `Panelist`. Esto incluye:
    - Inyección de `PanelistPropertyService`.
    - Adición de un `MultiSelectListBox` al formulario de edición.
    - Lógica para cargar las propiedades existentes del panelista en el `MultiSelectListBox`.
    - Lógica para guardar las propiedades seleccionadas en la relación N:N.
- Se confirmó que `PanelistService` no requiere cambios explícitos debido al uso de JPA y `CascadeType`.
- Se verificó que la configuración `spring.jpa.hibernate.ddl-auto = update` se encargará de crear la tabla de unión necesaria.

Esto te permite asignar múltiples propiedades a cada panelista desde la interfaz de edición.