### PR TITLE
Add findAll method to PanelistPropertyService

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
@@ -58,4 +58,8 @@ public class PanelistPropertyService {
         return (int) repository.count();
     }
 
+    public List<PanelistProperty> findAll() {
+        return repository.findAll();
+    }
+
 }


### PR DESCRIPTION
The method `findAll()` was undefined for the type `PanelistPropertyService`. This was causing an error in `PanelistsView.java` where it was trying to use this method to populate a list of properties.

This commit adds the `findAll()` method to `PanelistPropertyService.java`, which calls the corresponding `findAll()` method in `PanelistPropertyRepository.java`.

The existing call in `PanelistsView.java` now works correctly without any modifications to that file.

All tests pass with this change.