### PR TITLE
Fix ID generation for PanelistProperty and other entities

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/AbstractEntity.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/AbstractEntity.java
@@ -1,5 +1,6 @@
 package uy.com.equipos.panelmanagement.data;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +13,7 @@ public abstract class AbstractEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @jakarta.persistence.Column(columnDefinition="BIGINT AUTO_INCREMENT PRIMARY KEY")
     private Long id;
 
     @Version


### PR DESCRIPTION
The application was failing to save new PanelistProperty entities (and likely other entities extending AbstractEntity) due to the database error: "Field 'id' doesn't have a default value".

This was happening because the `@GeneratedValue(strategy = GenerationType.IDENTITY)` in `AbstractEntity.java` was not consistently creating an AUTO_INCREMENT primary key column in MariaDB, even with `spring.jpa.hibernate.ddl-auto=update`.

This commit resolves the issue by adding an explicit `@jakarta.persistence.Column(columnDefinition="BIGINT AUTO_INCREMENT PRIMARY KEY")` annotation to the `id` field in `AbstractEntity.java`. This ensures that Hibernate correctly defines the ID column as an auto-incrementing primary key when interacting with MariaDB.

All tests pass with this modification.