### PR TITLE
Soluciona `LazyInitializationException` y provee ajustes para la gene…

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
@@ -2,6 +2,7 @@ package uy.com.equipos.panelmanagement.data;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;


### PR DESCRIPTION
…ración de ID

Este commit incluye varias correcciones:

1.  Resuelve una `LazyInitializationException` en `PanelistsView` al acceder a la colección `Panelist.properties`. Se cambió el tipo de carga a `FetchType.EAGER` en la entidad `Panelist` para esta colección.

2.  Para abordar el problema de "Field 'id' doesn't have a default value" (reportado por ti como resuelto mediante cambios SQL manuales en tu BD local):
    *   Se añadió `@jakarta.persistence.Column(columnDefinition="BIGINT AUTO_INCREMENT PRIMARY KEY")` a la entidad `AbstractEntity` para que la definición de la columna ID sea más explícita para MariaDB.
    *   Se añadió un método `findAll()` a `PanelistPropertyService` que estaba ausente y era requerido por `PanelistsView` (issue original).

Te recomiendo probar estos cambios en tu entorno después de haber aplicado las modificaciones SQL necesarias en tu base de datos para asegurar que las columnas `id` de las tablas relevantes sean `AUTO_INCREMENT PRIMARY KEY` y que las restricciones de clave foránea se manejen adecuadamente.