### PR TITLE
Soluciona LazyInitializationException con @Transactional e inicializa…

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
@@ -4,10 +4,12 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.hibernate.Hibernate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import jakarta.persistence.criteria.Predicate;
 import uy.com.equipos.panelmanagement.data.Panelist;
 import uy.com.equipos.panelmanagement.data.PanelistRepository;
@@ -21,8 +23,11 @@ public class PanelistService {
         this.repository = repository;
     }
 
+    @Transactional(readOnly = true)
     public Optional<Panelist> get(Long id) {
-        return repository.findById(id);
+        Optional<Panelist> panelistOptional = repository.findById(id);
+        panelistOptional.ifPresent(panelist -> Hibernate.initialize(panelist.getProperties()));
+        return panelistOptional;
     }
 
     public Panelist save(Panelist entity) {


### PR DESCRIPTION
…ción explícita

Este commit aborda la `LazyInitializationException` que ocurría en `PanelistsView` al acceder a la colección `Panelist.properties`.

Cambios principales:
- Se ha modificado `PanelistService.get(Long id)`:
  - Se añadió la anotación `@Transactional(readOnly = true)`.
  - Se utiliza `Hibernate.initialize(panelist.getProperties())` para asegurar que la colección de propiedades se cargue dentro de la transacción activa antes de devolver la entidad Panelist.
  - Se agregaron las importaciones necesarias para `@Transactional` y `Hibernate`.

Este enfoque reemplaza o complementa el intento anterior de usar `FetchType.EAGER`.

Este commit también incluye cambios anteriores destinados a resolver el problema de generación de ID ("Field 'id' doesn't have a default value"):
- Adición de `@Column(columnDefinition="BIGINT AUTO_INCREMENT PRIMARY KEY")` en `AbstractEntity.java`.
- Adición del método `findAll()` en `PanelistPropertyService.java`.

Te recomiendo probar estos cambios en tu entorno, asumiendo que ya has aplicado las modificaciones SQL necesarias en tu base de datos local para que las columnas `id` sean `AUTO_INCREMENT PRIMARY KEY`.