### PR TITLE
fix: Resolve LazyInitializationException in property dialog

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistPropertyValue.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistPropertyValue.java
@@ -17,7 +17,7 @@ public class PanelistPropertyValue extends AbstractEntity {
     @NotNull
     private Panelist panelist;
 
-    @ManyToOne(fetch = FetchType.LAZY) // LAZY es generalmente preferible para relaciones ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "panelist_property_id")
     @NotNull
     private PanelistProperty panelistProperty;


### PR DESCRIPTION
This commit fixes a `LazyInitializationException` that occurred in the "Gestionar Propiedades para el Panelista" dialog. The error was triggered when accessing `PanelistProperty` instances that were lazily loaded and their Hibernate session was no longer active, typically when these instances were used in HashMaps or HashSets (triggering hashCode/equals).

The fix involves changing the fetch strategy for the `PanelistPropertyValue.panelistProperty` association from `FetchType.LAZY` to `FetchType.EAGER`. This ensures that the `PanelistProperty` entity is fully loaded whenever its parent `PanelistPropertyValue` is accessed, preventing the proxy initialization issues.

This change addresses the stack trace involving `PanelistProperty$HibernateProxy.hashCode` when the dialog was being created or interacted with.