### PR TITLE
fix: Change PanelistProperty.codes to FetchType.LAZY

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistProperty.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistProperty.java
@@ -17,7 +17,7 @@ public class PanelistProperty extends AbstractEntity {
     @Enumerated(EnumType.STRING)
     private PropertyType type;
 
-    @OneToMany(mappedBy = "panelistProperty", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "panelistProperty", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<PanelistPropertyCode> codes = new ArrayList<>();
 
     public String getName() {


### PR DESCRIPTION
I changed the fetch strategy for the 'codes' collection in the PanelistProperty entity from EAGER to LAZY.

This is intended to resolve a potential issue during application startup where Hibernate might attempt to access or create constraints related to the 'panelist_property_code' table before it is fully initialized, particularly when 'spring.jpa.hibernate.ddl-auto' is set to 'update'. Lazy loading defers the initialization of this collection, which should help prevent "Table 'paneles.panelist_property_code' doesn't exist" errors during DDL execution or early data queries.