### PR TITLE
fix: Address PanelistPropertyCode table existence errors during startup

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,14 @@
+-- Ensure panelist_property_code table exists before Hibernate attempts to manage it further
+CREATE TABLE IF NOT EXISTS panelist_property_code (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    version BIGINT,
+    code VARCHAR(255) NOT NULL,
+    description VARCHAR(255),
+    panelist_property_id BIGINT,
+    PRIMARY KEY (id)
+);
+
+-- It's also good practice to ensure the panelist_property table exists if it's referenced by FKs
+-- created by Hibernate later, or if panelist_property_code.panelist_property_id needs to be
+-- immediately valid (though Hibernate with ddl-auto=update should handle panelist_property itself).
+-- For now, focusing only on panelist_property_code as it's the one causing the immediate error.


### PR DESCRIPTION
This commit introduces two changes to prevent errors related to the `panelist_property_code` table not existing when Hibernate attempts to use or modify it during application startup or initial data access:

1.  **Added `src/main/resources/schema.sql`:** This file now includes a `CREATE TABLE IF NOT EXISTS panelist_property_code` statement. Spring Boot executes `schema.sql` before Hibernate's `ddl-auto=update` (when `spring.jpa.defer-datasource-initialization=true`), ensuring the table is present.

2.  **Changed `PanelistProperty.codes` to `FetchType.LAZY`:** Modified the `@OneToMany` relationship for the `codes` collection in `PanelistProperty.java` to use lazy loading. This was an earlier attempt to mitigate the issue and is retained as it's generally good practice.

These changes collectively aim to resolve `SQLGrammarException` and `CommandAcceptanceException` (Table 'paneles.panelist_property_code' doesn't exist) that were occurring.