### PR TITLE
Fix: Resolve LazyInitializationException for PanelistProperty.codes

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistProperty.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistProperty.java
@@ -17,7 +17,7 @@ public class PanelistProperty extends AbstractEntity {
     @Enumerated(EnumType.STRING)
     private PropertyType type;
 
-    @OneToMany(mappedBy = "panelistProperty", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "panelistProperty", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private List<PanelistPropertyCode> codes = new ArrayList<>();
 
     public String getName() {


### PR DESCRIPTION
The `codes` collection in the `PanelistProperty` entity was configured with `FetchType.LAZY`. This caused a `LazyInitializationException` when UI components (specifically Vaadin's ListDataProvider) attempted to access the collection outside of an active Hibernate session.

Changed the fetch strategy for `PanelistProperty.codes` to `FetchType.EAGER` to ensure the collection is loaded when the `PanelistProperty` entity itself is loaded. This makes the `codes` data available to the UI layer and prevents the exception.