### PR TITLE
fix: Usar @EntityGraph para resolver LazyInitializationException

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistPropertyRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistPropertyRepository.java
@@ -2,10 +2,14 @@ package uy.com.equipos.panelmanagement.data;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.EntityGraph; // Added import
+import java.util.Optional; // Added import
 
 public interface PanelistPropertyRepository
         extends
             JpaRepository<PanelistProperty, Long>,
             JpaSpecificationExecutor<PanelistProperty> {
 
+    @EntityGraph(attributePaths = {"codes"})
+    Optional<PanelistProperty> findByIdFetchingCodes(Long id);
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
@@ -22,7 +22,7 @@ public class PanelistPropertyService {
     }
 
     public Optional<PanelistProperty> get(Long id) {
-        return repository.findById(id);
+        return repository.findByIdFetchingCodes(id);
     }
 
     public PanelistProperty save(PanelistProperty entity) {

--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
@@ -230,9 +230,11 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
         codesManagementSection.setClassName("codes-management-section");
         codesManagementSection.setPadding(false);
         codesManagementSection.setSpacing(true); // Add some space between elements
+        codesManagementSection.setSizeFull(); // Allow codesManagementSection to fill available space
 
         codesGrid = new Grid<>(PanelistPropertyCode.class, false);
         codesGrid.setClassName("codes-grid");
+        codesGrid.setHeight("100%"); // Allow codesGrid to take full height within its container
         codesGrid.addColumn(PanelistPropertyCode::getCode).setHeader("Código").setAutoWidth(true);
         codesGrid.addColumn(PanelistPropertyCode::getDescription).setHeader("Descripción").setAutoWidth(true);
         codesGrid.addComponentColumn(code -> new Button(VaadinIcon.TRASH.create(), click -> {
@@ -250,11 +252,13 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
         addCodeButton = new Button("Añadir Código", VaadinIcon.PLUS.create(), event -> addCodeAction());
         addCodeButton.addThemeVariants(ButtonVariant.LUMO_SMALL);
 
-        HorizontalLayout newCodeLayout = new HorizontalLayout(newCodeValueField, newCodeDescriptionField, addCodeButton);
-        newCodeLayout.setAlignItems(Alignment.BASELINE);
-        newCodeLayout.setSpacing(true);
+        // Changed to VerticalLayout, components are added in the desired order.
+        VerticalLayout newCodeLayout = new VerticalLayout(newCodeValueField, newCodeDescriptionField, addCodeButton);
+        newCodeLayout.setSpacing(true); // Keep spacing, remove baseline alignment not typically used in VerticalLayout this way
         
-        codesManagementSection.add(new H2("Códigos"), codesGrid, newCodeLayout);
+        // Corrected order of components in codesManagementSection
+        codesManagementSection.add(new H2("Códigos"), newCodeLayout, codesGrid);
+        codesManagementSection.expand(codesGrid); // Make codesGrid take available space
         editorDiv.add(codesManagementSection); // Add section to editor
 
         // Initial visibility


### PR DESCRIPTION
Se revirtió el cambio anterior de FetchType.EAGER a FetchType.LAZY en PanelistProperty.codes. Se introdujo un método `findByIdFetchingCodes` en PanelistPropertyRepository anotado con `@EntityGraph(attributePaths = {"codes"})`. El servicio `PanelistPropertyService` fue actualizado para usar este nuevo método al obtener una PanelistProperty por ID.

Esto asegura que la colección 'codes' se cargue de manera explícita cuando sea necesario, resolviendo la `LazyInitializationException` sin forzar EAGER fetch globalmente.