### PR TITLE
Fix(PanelistProperty): Resolve UnsatisfiedDependencyException

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
@@ -22,7 +22,7 @@ public class PanelistPropertyService {
     }
 
     public Optional<PanelistProperty> get(Long id) {
-        return repository.findByIdFetchingCodes(id);
+        return repository.findById(id);
     }
 
     public PanelistProperty save(PanelistProperty entity) {


### PR DESCRIPTION
The application was failing to start due to an `UnsatisfiedDependencyException` when creating the `PanelistPropertyService`. This was caused by a call to a non-existent method `findByIdFetchingCodes` in the `PanelistPropertyRepository`.

The `PanelistPropertyRepository` already provides the intended functionality (eagerly fetching the 'codes' collection) through its overridden `findById` method, which is annotated with `@EntityGraph(attributePaths = {"codes"})`.

This commit updates the `PanelistPropertyService` to call the correct `findById` method on the `PanelistPropertyRepository`.