### PR TITLE
Fix: Prevent adding codes to unsaved properties

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
@@ -298,7 +298,7 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
     private void addCodeAction() {
         PanelistProperty currentProperty = binder.getBean();
 
-        if (currentProperty == null) {
+        if (currentProperty == null || currentProperty.getId() == null) {
             Notification.show("Por favor, seleccione o guarde la propiedad principal antes de añadir códigos.", 3000, Notification.Position.MIDDLE);
             return;
         }


### PR DESCRIPTION
The `addCodeAction` in `PropertiesView` was allowing attempts to add codes to a `PanelistProperty` that was newly created but not yet saved. This was because the check `currentProperty == null` was insufficient.

The fix modifies the condition to `currentProperty == null || currentProperty.getId() == null`. This ensures that a property must be saved (and thus have an ID) before codes can be added to it, resolving the erroneous notification display and preventing potential issues with associating codes to non-existent parent entities.