### PR TITLE
Fix: Ensure main property is available when adding codes in Propertie…

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
@@ -296,7 +296,7 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
     }
 
     private void addCodeAction() {
-        PanelistProperty currentProperty = binder.getBean();
+        PanelistProperty currentProperty = this.panelistProperty;
 
         if (currentProperty == null) {
             Notification.show("Por favor, seleccione o guarde la propiedad principal antes de añadir códigos.", 3000, Notification.Position.MIDDLE);


### PR DESCRIPTION
…sView

The error "Por favor, seleccione o guarde la propiedad principal antes de añadir códigos." occurred when you tried to add a code to a PanelistProperty. This was due to `binder.getBean()` returning null within the `addCodeAction` method, even if a property was loaded or being created.

The fix modifies `addCodeAction` to use `this.panelistProperty` directly instead of `binder.getBean()`. `this.panelistProperty` is consistently updated in `populateForm` and is expected to hold the correct reference to the property being edited. This change ensures that a valid property instance is used when adding a new code, resolving the issue for both new and existing properties of type 'CODIGO'.