### PR TITLE
Fix: Use this.panelistProperty in addCodeAction

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
@@ -300,7 +300,7 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
     }
 
     private void addCodeAction() {
-        PanelistProperty currentProperty = binder.getBean();
+        PanelistProperty currentProperty = this.panelistProperty;
 
         if (currentProperty == null) {
             Notification.show("Por favor, seleccione o guarde la propiedad principal antes de añadir códigos. ", 3000, Notification.Position.MIDDLE);


### PR DESCRIPTION
In PropertiesView.java, the addCodeAction method was changed to use this.panelistProperty directly instead of binder.getBean() to retrieve the current PanelistProperty instance.

This ensures that the correct property instance is used when adding a new code, particularly for new, unsaved properties. This resolves an issue where an error message ("Por favor, seleccione o guarde la propiedad principal antes de añadir códigos.") could appear incorrectly because binder.getBean() might return null in that context, even when the "Add Code" button was enabled.