### PR TITLE
Fix: Use this.panelistProperty for code deletion in PropertiesView

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
@@ -236,7 +236,7 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
         codesGrid.setClassName("codes-grid");
         //codesGrid.setHeight("100%"); // Allow codesGrid to take full height within its container
         codesGrid.addComponentColumn(code -> new Button(VaadinIcon.TRASH.create(), click -> {
-            PanelistProperty property = binder.getBean();
+            PanelistProperty property = this.panelistProperty;
             if (property != null) {
                 property.removeCode(code); // Use helper method
                 codesGrid.setItems(property.getCodes()); // Refresh grid


### PR DESCRIPTION
I changed the logic for deleting a code from the codesGrid in PropertiesView. Instead of using binder.getBean(), which could be null if the binder was not properly populated, the code now uses this.panelistProperty. This field is more reliably populated and ensures that the correct PanelistProperty object is used for code deletion.

This addresses an issue where deleting a code from a property of type 'CODIGO' would not work because binder.getBean() was evaluating to null.