### PR TITLE
feat: Implement dynamic editors for panelist properties

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistPropertyCodeRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistPropertyCodeRepository.java
@@ -2,10 +2,13 @@ package uy.com.equipos.panelmanagement.data;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import java.util.List; // Add this import
 
 public interface PanelistPropertyCodeRepository
         extends
             JpaRepository<PanelistPropertyCode, Long>,
             JpaSpecificationExecutor<PanelistPropertyCode> {
 
+    // Add this method
+    List<PanelistPropertyCode> findByPanelistProperty(PanelistProperty panelistProperty);
 }


### PR DESCRIPTION
Modifies the 'Edit Properties' dialog in PanelistsView to use different input components based on the property type:
- FECHA (Date): Uses a DatePicker.
- NUMERO (Number): Uses a TextField.
- CODIGO (Code): Uses a ComboBox populated with relevant codes from PanelistPropertyCodeRepository.
- TEXTO (Text): Uses a TextField.

Changes include:
- Added `findByPanelistProperty` to `PanelistPropertyCodeRepository`.
- Injected `PanelistPropertyCodeRepository` into `PanelistsView`.
- Updated `createGestionarPropiedadesDialog` in `PanelistsView`:
    - Changed `propertyValueFields` to store `Component` instead of `TextField`.
    - Implemented logic to switch editor components based on `PropertyType`.
    - Ensured existing values are populated correctly.
- Updated the save logic in the dialog to correctly retrieve values from the different component types and store them as strings.