### PR TITLE
feat: Implement Many-to-Many Panelist-Panel relationship and UI

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/Panel.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Panel.java
@@ -1,7 +1,11 @@
 package uy.com.equipos.panelmanagement.data;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToMany;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 public class Panel extends AbstractEntity {
@@ -29,4 +33,14 @@ public class Panel extends AbstractEntity {
         this.active = active;
     }
 
+    @ManyToMany(mappedBy = "panels", fetch = FetchType.LAZY)
+    private Set<Panelist> panelists = new HashSet<>();
+
+    public Set<Panelist> getPanelists() {
+        return panelists;
+    }
+
+    public void setPanelists(Set<Panelist> panelists) {
+        this.panelists = panelists;
+    }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
@@ -3,6 +3,9 @@ package uy.com.equipos.panelmanagement.data;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 // import jakarta.persistence.JoinColumn; // Not strictly needed by Panelist's own fields now
 // import jakarta.persistence.JoinTable; // Removed
 import jakarta.persistence.OneToMany;
@@ -57,5 +60,21 @@ public class Panelist extends AbstractEntity {
 
     public void setPropertyValues(Set<PanelistPropertyValue> propertyValues) {
         this.propertyValues = propertyValues;
+    }
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "panelist_panel",
+            joinColumns = @JoinColumn(name = "panelist_id"),
+            inverseJoinColumns = @JoinColumn(name = "panel_id")
+    )
+    private Set<Panel> panels = new HashSet<>();
+
+    public Set<Panel> getPanels() {
+        return panels;
+    }
+
+    public void setPanels(Set<Panel> panels) {
+        this.panels = panels;
     }
 }


### PR DESCRIPTION
- I defined a Many-to-Many relationship between Panelist and Panel entities. Panelist is the owning side of the relationship.

- I added a button 'Ver paneles en los que participa' to the Panelist form in PanelistsView. This button opens a dialog displaying a grid of panels associated with the selected panelist.

- The dialog grid allows you to remove a panelist's participation in a specific panel. Changes are persisted by saving the Panelist entity.

- I added PanelistService.removePanelFromPanelist method for explicit association removal, enhancing the service layer API.

- I updated PanelistsView to manage the display and removal of these associations.