### PR TITLE
feat: Add panelist linking to panels via wizard

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
@@ -3,6 +3,6 @@ package uy.com.equipos.panelmanagement.data;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface PanelistRepository extends JpaRepository<Panelist, Long>, JpaSpecificationExecutor<Panelist> {
+public interface PanelistRepository extends JpaRepository<Panelist, Long>, JpaSpecificationExecutor<Panelist>, PanelistRepositoryCustom {
 
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepositoryCustom.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepositoryCustom.java
@@ -1,0 +1,8 @@
+package uy.com.equipos.panelmanagement.data;
+
+import java.util.List;
+import java.util.Map;
+
+public interface PanelistRepositoryCustom {
+    List<Panelist> findByCriteria(Map<PanelistProperty, Object> criteria);
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepositoryImpl.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepositoryImpl.java
@@ -1,0 +1,115 @@
+package uy.com.equipos.panelmanagement.data;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.*;
+import uy.com.equipos.panelmanagement.data.PanelistProperty.Type; // Assuming Type is an inner enum
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class PanelistRepositoryImpl implements PanelistRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public List<Panelist> findByCriteria(Map<PanelistProperty, Object> criteria) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Panelist> query = cb.createQuery(Panelist.class);
+        Root<Panelist> panelistRoot = query.from(Panelist.class);
+
+        if (criteria == null || criteria.isEmpty()) {
+            query.select(panelistRoot);
+            return entityManager.createQuery(query).getResultList();
+        }
+
+        List<Predicate> allCriteriaPredicates = new ArrayList<>();
+
+        for (Map.Entry<PanelistProperty, Object> entry : criteria.entrySet()) {
+            PanelistProperty property = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null) continue;
+            if (value instanceof String && ((String) value).isBlank()) continue;
+
+            Subquery<Long> subquery = query.subquery(Long.class);
+            Root<Panelist> subqueryPanelistRoot = subquery.correlate(panelistRoot);
+            Join<Panelist, PanelistPropertyValue> ppvJoin = subqueryPanelistRoot.join("propertyValues");
+
+            Predicate propertyMatch = cb.equal(ppvJoin.get("panelistProperty"), property);
+            Predicate valueMatchPredicate = null;
+
+            String valueAsString = null;
+
+            switch (property.getType()) {
+                case TEXTO:
+                    if (value instanceof String) {
+                        valueMatchPredicate = cb.like(cb.lower(ppvJoin.get("value")), "%" + ((String) value).toLowerCase() + "%");
+                    }
+                    break;
+                case FECHA:
+                    if (value instanceof LocalDate) {
+                        // Dates are stored as strings, so format criteria to string for comparison
+                        // Assumes dates in DB are stored in ISO_LOCAL_DATE format (e.g., "2023-10-26")
+                        valueAsString = ((LocalDate) value).format(DateTimeFormatter.ISO_LOCAL_DATE);
+                        valueMatchPredicate = cb.equal(ppvJoin.get("value"), valueAsString);
+                    }
+                    break;
+                case NUMERO:
+                    // Numbers are stored as strings. For exact match, compare as strings.
+                    // This is not ideal for numeric comparisons (e.g., range queries)
+                    // but fits the current PanelistPropertyValue.value as String.
+                    if (value instanceof Number) {
+                        valueAsString = value.toString();
+                    } else if (value instanceof String) {
+                        // Validate if it's a number string before comparing? For now, direct comparison.
+                        valueAsString = (String) value;
+                    }
+                    if (valueAsString != null) {
+                        // This will perform a string comparison, e.g. "123" matches "123"
+                        // but "123.0" might not match "123" depending on DB storage.
+                        // For robust numeric comparison, PanelistPropertyValue.value would need to be numeric type
+                        // or use a CAST function if available and reliable.
+                        // For now, exact string match:
+                        valueMatchPredicate = cb.equal(ppvJoin.get("value"), valueAsString);
+                    }
+                    break;
+                case CODIGO:
+                    if (value instanceof PanelistPropertyCode) {
+                        // Assuming the 'code' field of PanelistPropertyCode is what's stored in PanelistPropertyValue.value
+                        valueAsString = ((PanelistPropertyCode) value).getCode();
+                        valueMatchPredicate = cb.equal(ppvJoin.get("value"), valueAsString);
+                    }
+                    break;
+            }
+
+            if (valueMatchPredicate != null) {
+                subquery.select(cb.literal(1L))
+                        .where(cb.and(propertyMatch, valueMatchPredicate));
+                allCriteriaPredicates.add(cb.exists(subquery));
+            } else {
+                // If a type is unhandled or value is of wrong type for a property,
+                // that property effectively won't be part of the filter.
+                // Or, we could add a predicate that is always false to ensure no results if a criterion is invalid.
+                // For now, just skipping.
+            }
+        }
+
+        if (!allCriteriaPredicates.isEmpty()) {
+            query.where(cb.and(allCriteriaPredicates.toArray(new Predicate[0])));
+        } else {
+            // If all criteria were skipped (e.g. null/blank values, or type mismatches not leading to a predicate)
+            // This means no effective filters were applied. Return all panelists or none based on requirements.
+            // To return all if all criteria are skipped: (do nothing, as no query.where() is called)
+            // To return none if all criteria are skipped: query.where(cb.disjunction()); // empty disjunction is false
+            // Current behavior: returns all if allCriteriaPredicates is empty.
+        }
+
+        query.select(panelistRoot).distinct(true);
+        return entityManager.createQuery(query).getResultList();
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
@@ -14,7 +14,11 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.criteria.Predicate;
 import uy.com.equipos.panelmanagement.data.Panel;
 import uy.com.equipos.panelmanagement.data.Panelist;
+import uy.com.equipos.panelmanagement.data.PanelistProperty;
 import uy.com.equipos.panelmanagement.data.PanelistRepository;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class PanelistService {
@@ -79,6 +83,23 @@ public class PanelistService {
 
     public int count() {
         return (int) repository.count();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Panelist> findPanelistsByCriteria(Map<PanelistProperty, Object> filterCriteria) {
+        if (filterCriteria == null || filterCriteria.isEmpty()) {
+            return repository.findAll(); // Or an empty list, as per requirements
+        }
+        // Remove entries with null or blank string values before passing to repository
+        Map<PanelistProperty, Object> finalCriteria = filterCriteria.entrySet().stream()
+            .filter(entry -> entry.getValue() != null)
+            .filter(entry -> !(entry.getValue() instanceof String) || !((String) entry.getValue()).isBlank())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (finalCriteria.isEmpty()) {
+             return repository.findAll(); // Or an empty list
+        }
+        return repository.findByCriteria(finalCriteria);
     }
 
     @Transactional

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
@@ -1,0 +1,160 @@
+package uy.com.equipos.panelmanagement.views.panels;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.binder.HasValue;
+import uy.com.equipos.panelmanagement.data.Panel;
+import uy.com.equipos.panelmanagement.data.PanelistProperty;
+import uy.com.equipos.panelmanagement.data.PanelistPropertyCode;
+import uy.com.equipos.panelmanagement.data.PanelistProperty.Type; // Assuming Type is an inner enum
+import uy.com.equipos.panelmanagement.repositories.PanelistPropertyCodeRepository;
+import uy.com.equipos.panelmanagement.services.PanelService; // Added
+import uy.com.equipos.panelmanagement.services.PanelistPropertyService;
+import uy.com.equipos.panelmanagement.services.PanelistService;
+
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PanelistPropertyFilterDialog extends Dialog {
+
+    private final PanelistPropertyService panelistPropertyService;
+    private final PanelistPropertyCodeRepository panelistPropertyCodeRepository;
+    private final PanelService globalPanelService; // Renamed for clarity from panelService to globalPanelService
+    private final PanelistService panelistService;
+    private final Panel currentPanel;
+
+    private Grid<PanelistProperty> propertiesGrid;
+    private Button cancelButton = new Button("Cancelar");
+    private Button searchButton = new Button("Buscar");
+
+    // To store references to the editor components
+    private Map<PanelistProperty, Component> propertyEditorMap = new HashMap<>();
+    private VerticalLayout contentLayout; // Made field
+
+    public PanelistPropertyFilterDialog(
+            PanelistPropertyService panelistPropertyService,
+            PanelistPropertyCodeRepository panelistPropertyCodeRepository,
+            PanelService globalPanelService, // Added
+            PanelistService panelistService,
+            Panel currentPanel) {
+        this.panelistPropertyService = panelistPropertyService;
+        this.panelistPropertyCodeRepository = panelistPropertyCodeRepository;
+        this.globalPanelService = globalPanelService; // Added
+        this.panelistService = panelistService;
+        this.currentPanel = currentPanel;
+
+        setHeaderTitle("Buscar Panelistas - Paso 1: Filtrar por Propiedades");
+        setWidth("600px"); // Set a width for the dialog
+
+        contentLayout = new VerticalLayout(); // Initialize field
+        contentLayout.setPadding(false);
+        contentLayout.setSpacing(true);
+        contentLayout.setAlignItems(Alignment.STRETCH); // Stretch items
+
+        propertiesGrid = new Grid<>(PanelistProperty.class, false);
+        propertiesGrid.addColumn(PanelistProperty::getName).setHeader("Propiedad").setFlexGrow(1);
+        propertiesGrid.addComponentColumn(this::createEditorComponentAndStore).setHeader("Valor").setFlexGrow(2);
+
+        List<PanelistProperty> properties = panelistPropertyService.findAll();
+        if (properties == null || properties.isEmpty()) {
+            propertiesGrid.setVisible(false); // Hide grid if no properties
+            Span noPropertiesMessage = new Span("No hay propiedades de panelista definidas para filtrar.");
+            noPropertiesMessage.getStyle().set("text-align", "center").set("font-style", "italic");
+            contentLayout.add(noPropertiesMessage);
+            searchButton.setEnabled(false); // Disable search if no properties
+        } else {
+            propertiesGrid.setItems(properties);
+            propertiesGrid.setWidthFull(); // Set width only if visible
+            contentLayout.add(propertiesGrid);
+        }
+
+        add(contentLayout);
+
+        getFooter().add(cancelButton, searchButton);
+
+        cancelButton.addClickListener(e -> close());
+        searchButton.addClickListener(e -> {
+            Map<PanelistProperty, Object> filterCriteria = new HashMap<>();
+            for (Map.Entry<PanelistProperty, Component> entry : propertyEditorMap.entrySet()) {
+                PanelistProperty prop = entry.getKey();
+                Component editor = entry.getValue();
+                Object value = null;
+
+                if (editor instanceof TextField) {
+                    value = ((TextField) editor).getValue();
+                    if (value != null && ((String) value).isEmpty()) value = null;
+                } else if (editor instanceof DatePicker) {
+                    value = ((DatePicker) editor).getValue();
+                } else if (editor instanceof ComboBox) {
+                    value = ((ComboBox<?>) editor).getValue();
+                }
+                // Add other types if needed
+
+                if (value != null) {
+                    filterCriteria.put(prop, value);
+                }
+            }
+
+            // Open Step 2 Dialog
+            PanelistSelectionDialog selectionDialog = new PanelistSelectionDialog(
+                    this.globalPanelService, this.panelistService, currentPanel, filterCriteria, this); // Added 'this'
+            selectionDialog.open();
+            // close(); // Do not close here anymore, PanelistSelectionDialog will close it
+        });
+    }
+
+    public void closeDialog() { // Added public method
+        this.close();
+    }
+
+    private Component createEditorComponentAndStore(PanelistProperty property) {
+        Component editor = createEditorComponent(property);
+        propertyEditorMap.put(property, editor); // Store the editor
+        return editor;
+    }
+
+    private Component createEditorComponent(PanelistProperty property) {
+        if (property == null || property.getType() == null) {
+            return new Span("Propiedad o tipo no definido");
+        }
+
+        Component editorComponent;
+        switch (property.getType()) {
+            case TEXTO:
+                editorComponent = new TextField();
+                break;
+            case FECHA:
+                editorComponent = new DatePicker();
+                break;
+            case NUMERO:
+                TextField numberField = new TextField();
+                numberField.setPattern("[0-9]*");
+                numberField.setPreventInvalidInput(true);
+                editorComponent = numberField;
+                break;
+            case CODIGO:
+                ComboBox<PanelistPropertyCode> comboBox = new ComboBox<>();
+                List<PanelistPropertyCode> codes = panelistPropertyCodeRepository.findByPanelistProperty(property);
+                comboBox.setItems(codes);
+                comboBox.setItemLabelGenerator(PanelistPropertyCode::getDescription);
+                editorComponent = comboBox;
+                break;
+            default:
+                editorComponent = new Span("Tipo no soportado: " + property.getType());
+        }
+        // Set width for all editor components to fill the cell
+        if (editorComponent instanceof HasValue) {
+            ((HasValue<?, ?>) editorComponent).getElement().getStyle().set("width", "100%");
+        }
+        return editorComponent;
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistSelectionDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistSelectionDialog.java
@@ -1,0 +1,198 @@
+package uy.com.equipos.panelmanagement.views.panels;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Span; // Added
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import uy.com.equipos.panelmanagement.data.Panel;
+import uy.com.equipos.panelmanagement.data.Panelist;
+import uy.com.equipos.panelmanagement.data.PanelistProperty;
+import uy.com.equipos.panelmanagement.services.PanelService; // Added
+import uy.com.equipos.panelmanagement.services.PanelistService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PanelistSelectionDialog extends Dialog {
+
+    private final PanelService panelServiceForPanel; // Service for Panel entities
+    private final PanelistService panelistServiceForPanelist; // Service for Panelist entities
+    private final Panel currentPanel;
+    private final Map<PanelistProperty, Object> filterCriteria;
+    private final PanelistPropertyFilterDialog ownerDialog; // Added
+
+    private VerticalLayout contentLayout; // Made field
+    private Grid<Panelist> panelistsGrid;
+    private List<Panelist> availablePanelists;
+    private Set<Panelist> selectedPanelists = new HashSet<>();
+
+    private Button selectAllButton = new Button("Seleccionar Todos");
+    private Button deselectAllButton = new Button("Deseleccionar Todos"); // Added for better UX
+    private Button cancelButton = new Button("Cancelar");
+    private Button saveButton = new Button("Guardar");
+
+    public PanelistSelectionDialog(
+            PanelService panelServiceForPanel,
+            PanelistService panelistServiceForPanelist,
+            Panel currentPanel,
+            Map<PanelistProperty, Object> filterCriteria,
+            PanelistPropertyFilterDialog ownerDialog) { // Added ownerDialog
+        this.panelServiceForPanel = panelServiceForPanel;
+        this.panelistServiceForPanelist = panelistServiceForPanelist;
+        this.currentPanel = currentPanel;
+        this.filterCriteria = filterCriteria != null ? filterCriteria : new HashMap<>();
+        this.ownerDialog = ownerDialog; // Added
+
+        setHeaderTitle("Buscar Panelistas - Paso 2: Seleccionar Panelistas");
+        setWidth("80%"); // Make dialog wider
+        setHeight("70%");
+
+        contentLayout = new VerticalLayout(); // Initialize field
+        contentLayout.setPadding(false);
+        contentLayout.setSpacing(true);
+        contentLayout.setSizeFull();
+        contentLayout.setAlignItems(Alignment.STRETCH);
+
+
+        panelistsGrid = new Grid<>(Panelist.class, false);
+        panelistsGrid.setSelectionMode(Grid.SelectionMode.NONE); // We handle selection with checkboxes
+
+        panelistsGrid.addComponentColumn(panelist -> {
+            Checkbox checkbox = new Checkbox();
+            checkbox.setValue(selectedPanelists.contains(panelist));
+            checkbox.addValueChangeListener(event -> {
+                if (event.getValue()) {
+                    selectedPanelists.add(panelist);
+                } else {
+                    selectedPanelists.remove(panelist);
+                }
+                updateButtonStates();
+            });
+            return checkbox;
+        }).setHeader("Seleccionar").setFlexGrow(0).setWidth("120px");
+
+        panelistsGrid.addColumn(Panelist::getFirstName).setHeader("Nombre").setSortable(true);
+        panelistsGrid.addColumn(Panelist::getLastName).setHeader("Apellido").setSortable(true);
+        panelistsGrid.addColumn(Panelist::getEmail).setHeader("Email").setSortable(true);
+        // TODO: Add other relevant Panelist fields as columns if needed
+
+        // Fetch panelists based on the provided criteria
+        if (this.panelistServiceForPanelist != null) {
+            this.availablePanelists = panelistServiceForPanelist.findPanelistsByCriteria(this.filterCriteria);
+        } else {
+            System.err.println("PanelistService (for Panelist) is null in PanelistSelectionDialog. Cannot fetch panelists.");
+            this.availablePanelists = new ArrayList<>();
+        }
+
+        if (this.availablePanelists == null || this.availablePanelists.isEmpty()) {
+            panelistsGrid.setVisible(false);
+            Span noPanelistsMessage = new Span("No se encontraron panelistas con los criterios especificados.");
+            noPanelistsMessage.getStyle().set("text-align", "center").set("font-style", "italic");
+            contentLayout.add(noPanelistsMessage);
+            selectAllButton.setEnabled(false);
+            deselectAllButton.setEnabled(false);
+            // saveButton is handled by updateButtonStates based on selection
+        } else {
+            panelistsGrid.setItems(this.availablePanelists);
+            panelistsGrid.setSizeFull();
+            contentLayout.add(panelistsGrid);
+            contentLayout.setFlexGrow(1, panelistsGrid); // Make grid take available space
+        }
+
+        add(contentLayout);
+
+        setupButtonLogic();
+        getFooter().add(selectAllButton, deselectAllButton, saveButton, cancelButton);
+        updateButtonStates();
+    }
+
+    private void setupButtonLogic() {
+        selectAllButton.addClickListener(e -> {
+            selectedPanelists.addAll(availablePanelists);
+            panelistsGrid.getDataProvider().refreshAll();
+            updateButtonStates();
+        });
+
+        deselectAllButton.addClickListener(e -> {
+            selectedPanelists.clear();
+            panelistsGrid.getDataProvider().refreshAll();
+            updateButtonStates();
+        });
+
+        cancelButton.addClickListener(e -> close());
+
+        saveButton.addClickListener(e -> {
+            if (this.currentPanel == null || this.currentPanel.getId() == null) { // Check ID for persisted panel
+                Notification.show("Error: No se ha especificado un panel válido.", 3000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+                return;
+            }
+            if (this.selectedPanelists == null || this.selectedPanelists.isEmpty()) {
+                Notification.show("No se han seleccionado panelistas.", 3000, Notification.Position.MIDDLE);
+                return;
+            }
+
+            try {
+                Set<Panelist> panelistsToUpdate = new HashSet<>();
+                int addedCount = 0;
+
+                for (Panelist selectedPanelist : this.selectedPanelists) {
+                    // Ensure Panelist's panels collection is initialized
+                    if (selectedPanelist.getPanels() == null) {
+                        selectedPanelist.setPanels(new HashSet<>());
+                    }
+
+                    if (selectedPanelist.getPanels().add(this.currentPanel)) {
+                        // Also update the panel's collection for consistency in the current object graph,
+                        // though the change to panelist.getPanels() is what JPA will persist.
+                        if (this.currentPanel.getPanelists() == null) {
+                            this.currentPanel.setPanelists(new HashSet<>());
+                        }
+                        this.currentPanel.getPanelists().add(selectedPanelist);
+
+                        panelistsToUpdate.add(selectedPanelist);
+                        addedCount++;
+                    }
+                }
+
+                if (addedCount > 0) {
+                    for (Panelist p : panelistsToUpdate) {
+                        // Assuming panelistServiceForPanelist can save a Panelist
+                        this.panelistServiceForPanelist.save(p);
+                    }
+                    Notification.show(addedCount + " panelista(s) vinculado(s) correctamente al panel: " + this.currentPanel.getName(), 5000, Notification.Position.BOTTOM_START)
+                        .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+                } else {
+                    Notification.show("Los panelistas seleccionados ya estaban vinculados o no se pudieron vincular.", 3000, Notification.Position.MIDDLE);
+                }
+
+                if (this.ownerDialog != null) {
+                    this.ownerDialog.closeDialog(); // Close the owner dialog (Step 1)
+                }
+                close(); // Close this dialog (Step 2)
+
+            } catch (Exception ex) {
+                Notification.show("Error al vincular panelistas: " + ex.getMessage(), 5000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+                ex.printStackTrace(); // For debugging
+            }
+        });
+    }
+
+    private void updateButtonStates() {
+        boolean hasSelection = !selectedPanelists.isEmpty();
+        boolean allSelected = !availablePanelists.isEmpty() && selectedPanelists.size() == availablePanelists.size();
+
+        saveButton.setEnabled(hasSelection);
+        selectAllButton.setEnabled(!allSelected);
+        deselectAllButton.setEnabled(hasSelection);
+    }
+}

--- a/src/test/java/uy/com/equipos/panelmanagement/services/PanelistServiceTest.java
+++ b/src/test/java/uy/com/equipos/panelmanagement/services/PanelistServiceTest.java
@@ -1,0 +1,131 @@
+package uy.com.equipos.panelmanagement.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uy.com.equipos.panelmanagement.data.Panelist;
+import uy.com.equipos.panelmanagement.data.PanelistProperty;
+import uy.com.equipos.panelmanagement.data.PanelistRepository;
+import uy.com.equipos.panelmanagement.data.PropertyType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PanelistServiceTest {
+
+    @Mock
+    private PanelistRepository panelistRepository;
+
+    @InjectMocks
+    private PanelistService panelistService;
+
+    private PanelistProperty textProperty;
+    private PanelistProperty dateProperty;
+
+    @BeforeEach
+    void setUp() {
+        textProperty = new PanelistProperty();
+        textProperty.setId(1L);
+        textProperty.setName("Location");
+        textProperty.setType(PropertyType.TEXTO);
+
+        dateProperty = new PanelistProperty();
+        dateProperty.setId(2L);
+        dateProperty.setName("BirthDate");
+        dateProperty.setType(PropertyType.FECHA);
+    }
+
+    @Test
+    void findPanelistsByCriteria_nullCriteria_callsRepositoryFindAll() {
+        when(panelistRepository.findAll()).thenReturn(Collections.singletonList(new Panelist()));
+
+        List<Panelist> result = panelistService.findPanelistsByCriteria(null);
+
+        assertThat(result).hasSize(1);
+        verify(panelistRepository).findAll();
+        verify(panelistRepository, never()).findByCriteria(anyMap());
+    }
+
+    @Test
+    void findPanelistsByCriteria_emptyCriteria_callsRepositoryFindAll() {
+        when(panelistRepository.findAll()).thenReturn(Collections.singletonList(new Panelist()));
+
+        List<Panelist> result = panelistService.findPanelistsByCriteria(new HashMap<>());
+
+        assertThat(result).hasSize(1);
+        verify(panelistRepository).findAll();
+        verify(panelistRepository, never()).findByCriteria(anyMap());
+    }
+
+    @Test
+    void findPanelistsByCriteria_criteriaWithNullValue_filtersOutNullValueAndCallsFindAllIfEmpty() {
+        Map<PanelistProperty, Object> criteria = new HashMap<>();
+        criteria.put(textProperty, null);
+
+        when(panelistRepository.findAll()).thenReturn(Collections.emptyList());
+
+        panelistService.findPanelistsByCriteria(criteria);
+
+        verify(panelistRepository).findAll(); // Because criteria becomes empty
+        verify(panelistRepository, never()).findByCriteria(anyMap());
+    }
+
+    @Test
+    void findPanelistsByCriteria_criteriaWithBlankStringValue_filtersOutBlankStringAndCallsFindAllIfEmpty() {
+        Map<PanelistProperty, Object> criteria = new HashMap<>();
+        criteria.put(textProperty, "   "); // Blank string
+
+        when(panelistRepository.findAll()).thenReturn(Collections.emptyList());
+
+        panelistService.findPanelistsByCriteria(criteria);
+
+        verify(panelistRepository).findAll(); // Because criteria becomes empty
+        verify(panelistRepository, never()).findByCriteria(anyMap());
+    }
+
+    @Test
+    void findPanelistsByCriteria_validCriteria_callsRepositoryFindByCriteria() {
+        Map<PanelistProperty, Object> criteria = new HashMap<>();
+        criteria.put(textProperty, "Montevideo");
+
+        when(panelistRepository.findByCriteria(anyMap())).thenReturn(Collections.singletonList(new Panelist()));
+
+        List<Panelist> result = panelistService.findPanelistsByCriteria(criteria);
+
+        assertThat(result).hasSize(1);
+        verify(panelistRepository, never()).findAll();
+        verify(panelistRepository).findByCriteria(eq(criteria)); // eq() to check map content
+    }
+
+    @Test
+    void findPanelistsByCriteria_mixedCriteria_filtersNullsAndBlanks_callsRepositoryFindByCriteria() {
+        Map<PanelistProperty, Object> criteria = new HashMap<>();
+        criteria.put(textProperty, "Montevideo");
+        criteria.put(dateProperty, null); // Should be filtered out
+        PanelistProperty numericProperty = new PanelistProperty();
+        numericProperty.setType(PropertyType.NUMERO); // Assuming PropertyType.NUMERO exists
+        numericProperty.setId(3L); // Give it an ID for equals/hashCode if map relies on it
+        numericProperty.setName("Age");
+        criteria.put(numericProperty, "  "); // Should be filtered out
+
+        Map<PanelistProperty, Object> expectedFilteredCriteria = new HashMap<>();
+        expectedFilteredCriteria.put(textProperty, "Montevideo");
+
+        when(panelistRepository.findByCriteria(anyMap())).thenReturn(Collections.emptyList());
+
+        panelistService.findPanelistsByCriteria(criteria);
+
+        verify(panelistRepository, never()).findAll();
+        // Verifying the map content after internal filtering by the service
+        verify(panelistRepository).findByCriteria(eq(expectedFilteredCriteria));
+    }
+}


### PR DESCRIPTION
I've implemented a feature allowing you to link Panelist entities to Panel entities from the Panel form in PanelsView.

Key changes include:

-   Added an "Agregar Panelistas" button to the PanelsView form.
-   Created a two-step wizard for selecting panelists:
    1.  PanelistPropertyFilterDialog: Allows you to filter panelists based on their properties. Input fields are dynamically generated based on property type (TEXTO, FECHA, NUMERO, CODIGO).
    2.  PanelistSelectionDialog: Displays panelists matching the filter criteria, allowing you to select one or more. Includes "Seleccionar Todos" and "Deseleccionar Todos" functionality.
-   Implemented panelist search logic in PanelistService and PanelistRepository using JPA Criteria API to find panelists based on multiple property values. This handles PanelistPropertyValue storing all values as Strings.
-   Implemented the logic in PanelistSelectionDialog to link selected panelists to the current panel. This correctly updates the owning side (Panelist) of the ManyToMany relationship.
-   Ensured necessary service methods (PanelistPropertyService.findAll, PanelistPropertyCodeRepository.findByPanelistProperty) are available and used.
-   Refined UI/UX by:
    -   Adding informative messages for empty states (no properties found, no panelists found).
    -   Implementing chained closing of the filter dialog when panelists are successfully linked.
-   Added unit tests for PanelistService focusing on the panelist search criteria logic.

This feature enhances panel management by providing a structured way to associate panelists based on specific characteristics.