### PR TITLE
feat: Add panelist linking to panels via wizard (with compilation fixes)

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistSelectionDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistSelectionDialog.java
@@ -5,6 +5,7 @@ import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Span; // Added
+import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment; // Added
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.NotificationVariant;

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
@@ -13,13 +13,13 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
 import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.H2;
+// import com.vaadin.flow.component.html.H2; // Unused
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.component.notification.NotificationVariant;
-import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
-import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
+// import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment; // Unused in this class
+// import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode; // Unused
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
@@ -42,7 +42,7 @@ import java.util.Optional;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.vaadin.lineawesome.LineAwesomeIconUrl;
 import uy.com.equipos.panelmanagement.data.Panel;
-import uy.com.equipos.panelmanagement.repositories.PanelistPropertyCodeRepository;
+import uy.com.equipos.panelmanagement.data.PanelistPropertyCodeRepository; // Corrected path
 import uy.com.equipos.panelmanagement.services.PanelService;
 import uy.com.equipos.panelmanagement.services.PanelistPropertyService;
 import uy.com.equipos.panelmanagement.services.PanelistService; // Added


### PR DESCRIPTION
I implemented a feature allowing you to link Panelist entities to Panel entities from the Panel form in PanelsView. This version includes corrections for compilation errors I identified after the initial commit.

Key changes include:

- Added an "Agregar Panelistas" button to the PanelsView form.
- Created a two-step wizard for selecting panelists:
    1.  PanelistPropertyFilterDialog: Allows you to filter panelists based on their properties. Input fields are dynamically generated based on property type (TEXTO, FECHA, NUMERO, CODIGO). Uses NumberField for numeric input.
    2.  PanelistSelectionDialog: Displays panelists matching the filter criteria, allowing you to select one or more. Includes "Seleccionar Todos" functionality.
- Implemented panelist search logic in PanelistService and PanelistRepository using JPA Criteria API to find panelists based on multiple property values. This handles PanelistPropertyValue storing all values as Strings.
- Implemented the logic in PanelistSelectionDialog to link selected panelists to the current panel. This correctly updates the owning side (Panelist) of the ManyToMany relationship.
- Ensured necessary service methods (PanelistPropertyService.findAll, PanelistPropertyCodeRepository.findByPanelistProperty) are available and used.
- Refined UI/UX by:
    - Adding informative messages for empty states (no properties found, no panelists found).
    - Implementing chained closing of the filter dialog when panelists are successfully linked.
- Added unit tests for PanelistService focusing on the panelist search criteria logic.
- Corrected various import statements and type usages across dialogs and services to resolve compilation errors.

Output: