### PR TITLE
feat: Add panelist linking to panels via wizard (compilation fixes v3)

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
@@ -152,7 +152,7 @@ public class PanelistPropertyFilterDialog extends Dialog {
                 break;
             case NUMERO:
                 NumberField numField = new NumberField();
-                numField.setPreventInvalidInput(true);
+                // numField.setPreventInvalidInput(true); // This method does not exist on NumberField
                 editorComponent = numField;
                 break;
             case CODIGO:
@@ -167,7 +167,10 @@ public class PanelistPropertyFilterDialog extends Dialog {
         }
         // Set width for all editor components to fill the cell
         if (editorComponent instanceof HasValue) {
-            ((HasValue<?, ?>) editorComponent).getElement().getStyle().set("width", "100%");
+            // getElement() is available on Component, so editorComponent.getElement() is fine.
+            // The HasValue check is okay if we might do other HasValue specific things,
+            // but for getElement, it's directly on Component.
+            editorComponent.getElement().getStyle().set("width", "100%");
         }
         return editorComponent;
     }


### PR DESCRIPTION
I've implemented a feature that allows you to link Panelist entities to Panel entities from the Panel form in PanelsView. This version includes multiple rounds of corrections for compilation errors I identified after initial commits.

Key changes include:

- Added an "Agregar Panelistas" button to the PanelsView form.
- Created a two-step wizard for selecting panelists:
    1.  PanelistPropertyFilterDialog: Allows you to filter panelists based on their properties. Input fields are dynamically generated based on property type (TEXTO, FECHA, NUMERO, CODIGO). Uses NumberField for numeric input.
    2.  PanelistSelectionDialog: Displays panelists matching the filter criteria, allowing you to select one or more. Includes "Seleccionar Todos" functionality.
- Implemented panelist search logic in PanelistService and PanelistRepository using JPA Criteria API to find panelists based on multiple property values. This handles PanelistPropertyValue storing all values as Strings.
- Implemented the logic in PanelistSelectionDialog to link selected panelists to the current panel. This correctly updates the owning side (Panelist) of the ManyToMany relationship.
- Ensured necessary service methods (PanelistPropertyService.findAll, PanelistPropertyCodeRepository.findByPanelistProperty) are available and used.
- Refined UI/UX by:
    - Adding informative messages for empty states (no properties found, no panelists found).
    - Implementing chained closing of the filter dialog when panelists are successfully linked.
- Added unit tests for PanelistService focusing on the panelist search criteria logic.
- Corrected various import statements, type usages, and method calls across dialogs and services to resolve compilation errors, including fixes for Alignment, HasValue, PanelistPropertyCodeRepository, PropertyType, TextField.setPreventInvalidInput, HasValue.getElement, and NumberField.setPreventInvalidInput.