### PR TITLE
Fix LazyInitializationException for Panel.panelists

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelRepository.java
@@ -2,7 +2,14 @@ package uy.com.equipos.panelmanagement.data;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PanelRepository extends JpaRepository<Panel, Long>, JpaSpecificationExecutor<Panel> {
+
+    @Query("SELECT p FROM Panel p LEFT JOIN FETCH p.panelists WHERE p.id = :id")
+    Optional<Panel> findByIdWithPanelists(@Param("id") Long id);
 
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelService.java
@@ -25,6 +25,10 @@ public class PanelService {
         return repository.findById(id);
     }
 
+    public Optional<Panel> getWithPanelists(Long id) {
+        return repository.findByIdWithPanelists(id);
+    }
+
     public Panel save(Panel entity) {
         return repository.save(entity);
     }

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistSelectionDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistSelectionDialog.java
@@ -143,7 +143,7 @@ public class PanelistSelectionDialog extends Dialog {
             }
 
             try {
-                Panel managedPanel = this.panelServiceForPanel.get(this.currentPanel.getId())
+                Panel managedPanel = this.panelServiceForPanel.getWithPanelists(this.currentPanel.getId())
                     .orElseThrow(() -> {
                         Notification.show("Error: El panel ya no existe.", 3000, Notification.Position.MIDDLE)
                                 .addThemeVariants(NotificationVariant.LUMO_ERROR);


### PR DESCRIPTION
Modify PanelService to use a JOIN FETCH query when retrieving a Panel for the PanelistSelectionDialog. This ensures the 'panelists' collection is initialized within an active Hibernate session, preventing the LazyInitializationException that occurred when the collection was accessed after the session had closed in the dialog's event handler.