### PR TITLE
Fix: Asegurar habilitación de campos de código para nuevas propiedades

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/propierties/PropertiesView.java
@@ -266,34 +266,34 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
 
         // Event handling for type ComboBox
         type.addValueChangeListener(event -> {
-            PropertyType selectedType = event.getValue();
+            PropertyType selectedType = event.getValue(); // Use the event's value directly
+            // PanelistProperty currentBean = binder.getBean(); // Previous
+            // boolean isPropertyBound = (currentBean != null); // Previous
+
+            // Use this.panelistProperty directly as it's assigned in populateForm
+            boolean isPropertyBound = (this.panelistProperty != null);
             boolean isTypeCodigo = PropertyType.CODIGO.equals(selectedType);
 
-            codesManagementSection.setVisible(isTypeCodigo);
+            boolean enableCodeControls = isPropertyBound && isTypeCodigo;
+            boolean showCodesSection = isTypeCodigo; // Section visibility depends only on type being CODIGO
 
-            // Enable controls if the type is CODIGO.
-            // Assumes that if the user is interacting, this.panelistProperty is (or will be) set.
-            boolean enableCodeControls = isTypeCodigo;
+            codesManagementSection.setVisible(showCodesSection);
 
+            // Enable/disable individual controls
             if (newCodeValueField != null) newCodeValueField.setEnabled(enableCodeControls);
             if (newCodeDescriptionField != null) newCodeDescriptionField.setEnabled(enableCodeControls);
             if (addCodeButton != null) addCodeButton.setEnabled(enableCodeControls);
 
-            if (this.panelistProperty != null) {
-                // The ComboBox 'type' is bound, so this.panelistProperty.setType()
-                // should be handled by the binder when binder.writeBean() is called.
-                // Or, if the binding is two-way and updates on value change, it's already set.
-                if (isTypeCodigo) {
+            // Grid visibility is part of codesManagementSection, but items depend on the bean
+            if (codesGrid != null) {
+                if (showCodesSection && this.panelistProperty != null) { // Show grid content if section visible AND this.panelistProperty exists
                     if (this.panelistProperty.getCodes() == null) {
                         this.panelistProperty.setCodes(new ArrayList<>());
                     }
                     codesGrid.setItems(this.panelistProperty.getCodes());
                 } else {
-                    codesGrid.setItems(new ArrayList<>());
+                    codesGrid.setItems(new ArrayList<>()); // Clear grid if not CODIGO or no panelistProperty
                 }
-            } else {
-                // If this.panelistProperty is null, there are no codes to show.
-                codesGrid.setItems(new ArrayList<>());
             }
         });
         
@@ -380,11 +380,12 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
             boolean isCodigo = PropertyType.CODIGO.equals(value.getType());
             codesManagementSection.setVisible(isCodigo);
             
-            // Enable controls if the type is CODIGO. (value is confirmed not null here)
-            boolean enableCodeControls = isCodigo;
+            // Enable controls only if property type is CODIGO and property is not null (selected or new)
+            boolean enableCodeControls = isCodigo && (value != null);
             newCodeValueField.setEnabled(enableCodeControls);
             newCodeDescriptionField.setEnabled(enableCodeControls);
             addCodeButton.setEnabled(enableCodeControls);
+            // codesGrid.setEnabled(enableCodeControls); // Grid itself might not need to be disabled, just its content managed
 
             if (isCodigo) {
                 codesGrid.setItems(value.getCodes() != null ? value.getCodes() : new ArrayList<>());
@@ -397,23 +398,31 @@ public class PropertiesView extends Div implements BeforeEnterObserver {
             newCodeValueField.setEnabled(false);
             newCodeDescriptionField.setEnabled(false);
             addCodeButton.setEnabled(false);
+            // codesGrid.setEnabled(false);
         }
     }
 
     private void clearForm() {
-        populateForm(null);
+        populateForm(null); // This will also hide codesManagementSection and clear grid
         if (editorLayoutDiv != null) {
             editorLayoutDiv.setVisible(false);
         }
         if (deleteButton != null) {
             deleteButton.setEnabled(false);
         }
+        // Explicitly ensure type combo is cleared and code fields too
         if (type != null) {
-            type.clear();
+            type.clear(); // This will trigger its value change listener which should handle disabling code fields
         }
-        // newCodeValueField, newCodeDescriptionField, addCodeButton are disabled by populateForm(null)
-        // or by the type.clear() listener.
-        if (newCodeValueField != null) newCodeValueField.clear();
+        // The populateForm(null) call already handles hiding the section and clearing the grid.
+        // The type.clear() above, through its listener, should ensure controls are disabled.
+        // However, an explicit disable here is safer if the listener logic changes or has complex conditions.
+        newCodeValueField.setEnabled(false);
+        newCodeDescriptionField.setEnabled(false);
+        addCodeButton.setEnabled(false);
+        // codesGrid.setEnabled(false); // If grid itself needs disabling
+
+        if (newCodeValueField != null) newCodeValueField.clear(); // Still good to clear values
         if (newCodeDescriptionField != null) newCodeDescriptionField.clear();
     }
 


### PR DESCRIPTION
Se ajustó la lógica en `PropertiesView.java` para corregir un problema donde los campos para agregar códigos permanecían deshabilitados al crear una nueva propiedad y seleccionar el tipo 'CODIGO'.

La principal modificación consiste en basar la condición de 'propiedad ligada' (`isPropertyBound`) en la instancia `this.panelistProperty` directamente, en lugar de `binder.getBean()`, dentro del listener de cambio de valor del ComboBox de tipo. Esto proporciona una referencia más directa y robusta al bean que se está editando, especialmente para nuevas instancias.

También se aseguró que la carga de ítems en `codesGrid` use `this.panelistProperty` de manera consistente.