### PR TITLE
Add 'View Panelists' button and dialog to PanelsView

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
+import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.binder.ValidationException;
@@ -74,6 +75,7 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 	private final Button save = new Button("Guardar");
 	private Button deleteButton; // Add this with other button declarations
 	private Button addPanelistsButton;
+	private Button viewPanelistsButton; // Added
 	private Button nuevoPanelButton;
 
 	private final BeanValidationBinder<Panel> binder;
@@ -107,6 +109,16 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 				PanelistPropertyFilterDialog filterDialog = new PanelistPropertyFilterDialog(
 						panelistPropertyService, panelistPropertyCodeRepository, this.panelService, panelistService, this.panel);
 				filterDialog.open();
+			} else {
+				Notification.show("Seleccione un panel primero.", 3000, Notification.Position.MIDDLE);
+			}
+		});
+
+		viewPanelistsButton = new Button("Ver Panelistas");
+		viewPanelistsButton.setEnabled(false);
+		viewPanelistsButton.addClickListener(e -> {
+			if (this.panel != null && this.panel.getId() != null) {
+				showPanelistsDialog();
 			} else {
 				Notification.show("Seleccione un panel primero.", 3000, Notification.Position.MIDDLE);
 			}
@@ -280,7 +292,7 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 		buttonLayout.setClassName("button-layout");
 		cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
 		save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-		buttonLayout.add(addPanelistsButton,save, deleteButton, cancel);
+		buttonLayout.add(addPanelistsButton, viewPanelistsButton, save, deleteButton, cancel); // Added viewPanelistsButton
 		editorLayoutDiv.add(buttonLayout);
 	}
 
@@ -311,6 +323,9 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 		if (addPanelistsButton != null) {
 			addPanelistsButton.setEnabled(value != null && value.getId() != null);
 		}
+		if (viewPanelistsButton != null) { // Added
+			viewPanelistsButton.setEnabled(value != null && value.getId() != null);
+		}
 	}
 
 	private void clearForm() {
@@ -321,6 +336,9 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 		}
 		if (addPanelistsButton != null) {
 			addPanelistsButton.setEnabled(false);
+		}
+		if (viewPanelistsButton != null) { // Added
+			viewPanelistsButton.setEnabled(false);
 		}
 	}
 
@@ -354,6 +372,15 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 			}
 		});
 		dialog.open();
+	}
+
+	private void showPanelistsDialog() {
+		if (this.panel != null && this.panel.getId() != null) {
+			ViewPanelistsDialog dialog = new ViewPanelistsDialog(this.panel, this.panelService);
+			dialog.open();
+		} else {
+			Notification.show("No hay un panel seleccionado.", 3000, Notification.Position.MIDDLE);
+		}
 	}
 	// Cambio trivial para republicar en nueva rama
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/ViewPanelistsDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/ViewPanelistsDialog.java
@@ -1,0 +1,53 @@
+package uy.com.equipos.panelmanagement.views.panels;
+
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import uy.com.equipos.panelmanagement.data.Panel;
+import uy.com.equipos.panelmanagement.data.Panelist;
+import uy.com.equipos.panelmanagement.services.PanelService;
+
+import java.util.Collections;
+
+public class ViewPanelistsDialog extends Dialog {
+
+    private Panel panel;
+    private PanelService panelService;
+
+    private Grid<Panelist> grid = new Grid<>(Panelist.class, false);
+
+    public ViewPanelistsDialog(Panel panel, PanelService panelService) {
+        this.panel = panel;
+        this.panelService = panelService;
+
+        setWidth("80%");
+        setHeight("70%");
+
+        configureGrid();
+        loadPanelists();
+
+        VerticalLayout layout = new VerticalLayout(grid);
+        layout.setSizeFull();
+        add(layout);
+
+        setCloseOnEsc(true);
+        setCloseOnOutsideClick(true);
+    }
+
+    private void configureGrid() {
+        grid.addColumn(Panelist::getFirstName).setHeader("Nombre").setAutoWidth(true);
+        grid.addColumn(Panelist::getLastName).setHeader("Apellido").setAutoWidth(true);
+        grid.addColumn(Panelist::getEmail).setHeader("Email").setAutoWidth(true);
+        // Add more columns as needed, e.g., phone, etc.
+    }
+
+    private void loadPanelists() {
+        if (panel != null && panel.getId() != null) {
+            panelService.getWithPanelists(panel.getId()).ifPresent(p -> {
+                grid.setItems(p.getPanelists());
+            });
+        } else {
+            grid.setItems(Collections.emptyList());
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new 'View Panelists' button in the Panel edit form within PanelsView. Clicking this button opens a dialog that displays a grid of all panelists associated with the currently selected Panel.

Key changes:
- Added 'Ver Panelistas' button to `PanelsView.java`.
- Created `ViewPanelistsDialog.java` to display panelists in a grid.
- Ensured `PanelService` and `PanelRepository` correctly fetch panelists for the dialog.