### PR TITLE
Add Close button to ViewPanelistsDialog

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/ViewPanelistsDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/ViewPanelistsDialog.java
@@ -45,7 +45,11 @@ public class ViewPanelistsDialog extends Dialog {
         configureGrid();
         loadPanelists();
 
-        VerticalLayout layout = new VerticalLayout(title, grid); // Added title
+        Button closeButton = new Button("Cerrar", e -> this.close());
+        closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        getFooter().add(closeButton); // Add button to dialog footer
+
+        VerticalLayout layout = new VerticalLayout(title, grid);
         layout.setSizeFull();
         layout.setFlexGrow(1, grid); // Make grid take available space
         add(layout);


### PR DESCRIPTION
This commit adds a 'Cerrar' (Close) button to the footer of the `ViewPanelistsDialog`. Clicking this button will close the dialog.