### PR TITLE
FIX: Resolver error de inicialización de variable y simplificar cierr…

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
@@ -140,18 +140,20 @@ public class PanelistPropertyFilterDialog extends Dialog {
 
             if (searchListener != null) {
                 searchListener.onSearch(filterCriteria);
+                // Si hay un listener, asumimos que el flujo continuará en otro diálogo,
+                // por lo que este diálogo de filtro debe cerrarse.
+                close();
             }
-            // La decisión de cerrar este diálogo y abrir el siguiente
-            // se manejará en la implementación del SearchListener en PanelistsView.
-            // Por defecto, este diálogo ya no abre PanelistSelectionDialog directamente.
-            // close(); // No cerrar aquí automáticamente.
+            // Si no hay searchListener, el diálogo permanecerá abierto (comportamiento anterior
+            // cuando PanelistPropertyFilterDialog abría PanelistSelectionDialog directamente).
+            // Sin embargo, con el refactor, siempre debería haber un searchListener si se espera una acción.
         });
     }
 
-    // Este método ya no es necesario si PanelistSelectionDialog no llama a closeDialog() de esta clase.
-    // public void closeDialog() {
-    //     this.close();
-    // }
+    // Mantener closeDialog() por si es llamado externamente, aunque el flujo principal ahora cierra internamente.
+    public void closeDialog() {
+        this.close();
+    }
 
     private Component createEditorComponentAndStore(PanelistProperty property) {
         Component editor = createEditorComponent(property);

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
@@ -143,27 +143,26 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 							// Para esto, filterDialog debe ser efectivamente final.
 						}
 				);
-
-				// Para poder pasar 'filterDialog' al SearchListener de sí mismo, necesitamos una variable final.
-				final PanelistPropertyFilterDialog finalFilterDialog = new PanelistPropertyFilterDialog(
+				// Ya no se necesita la variable 'finalFilterDialog' ya que PanelistPropertyFilterDialog
+				// se cierra a sí mismo después de invocar el SearchListener.
+				PanelistPropertyFilterDialog filterDialog = new PanelistPropertyFilterDialog(
 						panelistPropertyService,
 						panelistPropertyCodeRepository,
-						this.panelService,
-						panelistService,
-						this.panel,
-						filterCriteria -> {
+						this.panelService, // globalPanelService
+						panelistService,    // panelistService
+						this.panel,         // currentPanel
+						filterCriteria -> { // SearchListener implementation
 							PanelistSelectionDialog selectionDialog = new PanelistSelectionDialog(
-									this.panelService,
-									this.panelistService,
-									this.panel,
-									filterCriteria,
-									finalFilterDialog // Pasar la referencia del primer diálogo para que el segundo pueda cerrarlo
+									this.panelService,      // PanelService for Panel
+									this.panelistService,   // PanelistService for Panelist
+									this.panel,             // currentPanel
+									filterCriteria,         // los criterios del primer diálogo
+									null                    // ownerDialog es null, ya que el primer diálogo se cierra solo.
 							);
 							selectionDialog.open();
-							// No cerramos finalFilterDialog aquí, PanelistSelectionDialog lo hará si es necesario.
 						}
 				);
-				finalFilterDialog.open();
+				filterDialog.open();
 
 			} else {
 				Notification.show("Seleccione un panel primero.", 3000, Notification.Position.MIDDLE);


### PR DESCRIPTION
…e de diálogos

Se corrige el error 'The local variable finalFilterDialog may not have been initialized' en PanelsView.java.

Cambios:
- PanelistPropertyFilterDialog ahora se cierra a sí mismo después de invocar a su SearchListener.
- PanelsView.java ya no necesita pasar una referencia de PanelistPropertyFilterDialog a PanelistSelectionDialog, ya que el primero se cierra automáticamente.
- PanelistSelectionDialog ya maneja correctamente un ownerDialog nulo.