### PR TITLE
Fix Java compilation errors and duplicate variable

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
@@ -2,6 +2,7 @@ package uy.com.equipos.panelmanagement.views.panels;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Checkbox; // Added import
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.dialog.Dialog;
@@ -40,7 +41,7 @@ public class PanelistPropertyFilterDialog extends Dialog {
 
     // To store references to the editor components and checkboxes
     private Map<PanelistProperty, Component> propertyEditorMap = new HashMap<>();
-    private Map<PanelistProperty, Checkbox> propertyCheckboxMap = new HashMap<>();
+    private Map<PanelistProperty, Checkbox> propertyCheckboxMap = new HashMap<PanelistProperty, Checkbox>();
     private VerticalLayout contentLayout; // Made field
 
     // Listener para comunicar los filtros seleccionados

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
@@ -121,45 +121,11 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 									this.panelistService,   // PanelistService for Panelist
 									this.panel,             // currentPanel
 									filterCriteria,         // los criterios del primer diálogo
-									null // ownerDialog - PanelistSelectionDialog ahora puede tomar null si no necesita cerrar un owner específico
-									// O, si PanelistSelectionDialog necesita cerrar PanelistPropertyFilterDialog,
-									// necesitaríamos una forma de pasar la referencia de filterDialog aquí.
-									// Por ahora, asumimos que PanelistSelectionDialog puede manejar un ownerDialog nulo
-									// o que cerraremos filterDialog explícitamente después de abrir selectionDialog.
-							);
-							// Para mantener el comportamiento anterior donde PanelistSelectionDialog cerraba su "owner",
-							// necesitaríamos que PanelistPropertyFilterDialog se pase a sí mismo de alguna manera.
-							// Una solución más simple es que el SearchListener sea responsable de cerrar el primer diálogo.
-							// filterDialog.close(); // Cerrar el primer diálogo antes de abrir el segundo.
-							// Sin embargo, PanelistSelectionDialog ya tiene lógica para cerrar su ownerDialog.
-							// Vamos a necesitar pasar filterDialog a PanelistSelectionDialog.
-							// Esto requiere que filterDialog sea final o efectivamente final.
-							// La forma más limpia es modificar PanelistSelectionDialog para que no dependa de cerrar
-							// su owner, o que PanelistPropertyFilterDialog se cierre a sí mismo al disparar el evento.
-
-							// Solución: El SearchListener en PanelistPropertyFilterDialog no cierra el dialogo.
-							// PanelistSelectionDialog SÍ cierra a su owner (PanelistPropertyFilterDialog)
-							// si se le pasa. Así que debemos pasar filterDialog.
-							// Para esto, filterDialog debe ser efectivamente final.
-						}
-				);
-				// Ya no se necesita la variable 'finalFilterDialog' ya que PanelistPropertyFilterDialog
-				// se cierra a sí mismo después de invocar el SearchListener.
-				PanelistPropertyFilterDialog filterDialog = new PanelistPropertyFilterDialog(
-						panelistPropertyService,
-						panelistPropertyCodeRepository,
-						this.panelService, // globalPanelService
-						panelistService,    // panelistService
-						this.panel,         // currentPanel
-						filterCriteria -> { // SearchListener implementation
-							PanelistSelectionDialog selectionDialog = new PanelistSelectionDialog(
-									this.panelService,      // PanelService for Panel
-									this.panelistService,   // PanelistService for Panelist
-									this.panel,             // currentPanel
-									filterCriteria,         // los criterios del primer diálogo
 									null                    // ownerDialog es null, ya que el primer diálogo se cierra solo.
 							);
 							selectionDialog.open();
+							// PanelistPropertyFilterDialog se cierra a sí mismo después de invocar el SearchListener,
+							// por lo que no necesitamos cerrar filterDialog aquí explícitamente.
 						}
 				);
 				filterDialog.open();


### PR DESCRIPTION
- Added missing import for `com.vaadin.flow.component.checkbox.Checkbox` in `PanelistPropertyFilterDialog.java`.
- Explicitly specified generic type arguments for `HashMap` in `PanelistPropertyFilterDialog.java`.
- Resolved `addComponentColumn` type inference by ensuring `Checkbox` type was available.
- Fixed duplicate `filterDialog` local variable in `PanelsView.java` and consolidated event listener logic.