### PR TITLE
Fix LazyInitializationException in PanelistsView for surveys

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
@@ -2,7 +2,13 @@ package uy.com.equipos.panelmanagement.data;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PanelistRepository extends JpaRepository<Panelist, Long>, JpaSpecificationExecutor<Panelist>, PanelistRepositoryCustom {
 
+    @Query("SELECT p FROM Panelist p LEFT JOIN FETCH p.surveys WHERE p.id = :id")
+    Optional<Panelist> findByIdWithSurveys(@Param("id") Long id);
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
@@ -32,8 +32,15 @@ public class PanelistService {
     @Transactional(readOnly = true)
     public Optional<Panelist> get(Long id) {
         Optional<Panelist> panelistOptional = repository.findById(id);
-        panelistOptional.ifPresent(panelist -> Hibernate.initialize(panelist.getPropertyValues()));
+        // propertyValues is EAGER, explicit Hibernate.initialize is not strictly needed here.
+        // panelistOptional.ifPresent(panelist -> Hibernate.initialize(panelist.getPropertyValues()));
         return panelistOptional;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Panelist> getWithSurveys(Long id) {
+        // findByIdWithSurveys will fetch surveys. propertyValues and panels are EAGER.
+        return repository.findByIdWithSurveys(id);
     }
 
     public Panelist save(Panelist entity) {


### PR DESCRIPTION
Resolved an org.hibernate.LazyInitializationException that occurred when trying to view the surveys a panelist participated in.

This issue was caused by accessing the lazily-loaded 'surveys' collection of a 'Panelist' entity after the Hibernate session had closed. The fix mirrors the approach used for Survey.panelists.

Changes:
- Added `findByIdWithSurveys` method to `PanelistRepository` using a JPQL query with `LEFT JOIN FETCH` to eagerly load the 'surveys' collection.
- Added a corresponding `getWithSurveys` method to `PanelistService`.
- Updated `PanelistsView.beforeEnter` to use `getWithSurveys` when loading a panelist via URL parameters.
- Updated `PanelistsView.openParticipatingSurveysDialog` to re-fetch the selected panelist using `getWithSurveys` to ensure the 'surveys' collection is initialized before being accessed.
- Commented out a redundant Hibernate.initialize call in PanelistService for an EAGER collection.