### PR TITLE
Fix: Resolve LazyInitializationException for surveys

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
@@ -2,7 +2,14 @@ package uy.com.equipos.panelmanagement.data;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PanelistRepository extends JpaRepository<Panelist, Long>, JpaSpecificationExecutor<Panelist>, PanelistRepositoryCustom {
+
+    @Query("SELECT p FROM Panelist p LEFT JOIN FETCH p.surveys WHERE p.id = :id")
+    Optional<Panelist> findByIdWithSurveys(@Param("id") Long id);
 
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
@@ -32,8 +32,16 @@ public class PanelistService {
     @Transactional(readOnly = true)
     public Optional<Panelist> get(Long id) {
         Optional<Panelist> panelistOptional = repository.findById(id);
-        panelistOptional.ifPresent(panelist -> Hibernate.initialize(panelist.getPropertyValues()));
+        panelistOptional.ifPresent(panelist -> {
+            Hibernate.initialize(panelist.getPropertyValues());
+            Hibernate.initialize(panelist.getSurveys()); // Initialize surveys as well
+        });
         return panelistOptional;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Panelist> findByIdWithSurveys(Long id) {
+        return repository.findByIdWithSurveys(id);
     }
 
     public Panelist save(Panelist entity) {


### PR DESCRIPTION
Addresses an org.hibernate.LazyInitializationException that occurred when trying to access the 'surveys' collection of a Panelist entity from the PanelistsView after the Hibernate session was closed.

The solution involves:
1. Adding a new method `findByIdWithSurveys` to `PanelistRepository` and `PanelistService` that uses a JOIN FETCH query to eagerly load the `surveys` collection.
2. Modifying `PanelistsView.openParticipatingSurveysDialog()` to call this new service method, ensuring the `surveys` are loaded when the dialog is opened.
3. Enhancing `PanelistService.get(Long id)` to also initialize the `surveys` collection using `Hibernate.initialize()`, providing consistency when a panelist is loaded directly via URL.