### PR TITLE
Refactor Survey-Panelist N:N to SurveyPanelistParticipation entity

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
@@ -4,14 +4,11 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
 // import jakarta.persistence.JoinColumn; // Not strictly needed by Panelist's own fields now
 // import jakarta.persistence.JoinTable; // Removed
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.Email;
 import java.time.LocalDate;
-import java.util.Set; // Added for Set<Survey>
 import java.util.HashSet;
 import java.util.Set;
 // PanelistPropertyValue is in the same package
@@ -79,14 +76,14 @@ public class Panelist extends AbstractEntity {
         this.panels = panels;
     }
 
-    @ManyToMany(mappedBy = "panelists", fetch = FetchType.LAZY)
-    private Set<Survey> surveys = new HashSet<>();
+    @OneToMany(mappedBy = "panelist")
+    private Set<SurveyPanelistParticipation> participations = new HashSet<>();
 
-    public Set<Survey> getSurveys() {
-        return surveys;
+    public Set<SurveyPanelistParticipation> getParticipations() {
+        return participations;
     }
 
-    public void setSurveys(Set<Survey> surveys) {
-        this.surveys = surveys;
+    public void setParticipations(Set<SurveyPanelistParticipation> participations) {
+        this.participations = participations;
     }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
@@ -9,7 +9,9 @@ import java.util.Optional;
 
 public interface PanelistRepository extends JpaRepository<Panelist, Long>, JpaSpecificationExecutor<Panelist>, PanelistRepositoryCustom {
 
-    @Query("SELECT p FROM Panelist p LEFT JOIN FETCH p.surveys WHERE p.id = :id")
-    Optional<Panelist> findByIdWithSurveys(@Param("id") Long id);
+    // Ya no se necesita findByIdWithSurveys, se usará la carga EAGER/LAZY definida en la entidad
+    // o se creará un método específico para cargar participaciones si es necesario.
+    // @Query("SELECT p FROM Panelist p LEFT JOIN FETCH p.participations WHERE p.id = :id")
+    // Optional<Panelist> findByIdWithParticipations(@Param("id") Long id);
 
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/Survey.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Survey.java
@@ -3,10 +3,7 @@ package uy.com.equipos.panelmanagement.data;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -24,13 +21,8 @@ public class Survey extends AbstractEntity {
     @NotNull
     private Tool tool;
 
-    @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(
-            name = "survey_panelist",
-            joinColumns = @JoinColumn(name = "survey_id"),
-            inverseJoinColumns = @JoinColumn(name = "panelist_id")
-    )
-    private Set<Panelist> panelists = new HashSet<>();
+    @OneToMany(mappedBy = "survey")
+    private Set<SurveyPanelistParticipation> participations = new HashSet<>();
 
     public String getName() {
         return name;
@@ -59,11 +51,11 @@ public class Survey extends AbstractEntity {
         this.tool = tool;
     }
 
-    public Set<Panelist> getPanelists() {
-        return panelists;
+    public Set<SurveyPanelistParticipation> getParticipations() {
+        return participations;
     }
 
-    public void setPanelists(Set<Panelist> panelists) {
-        this.panelists = panelists;
+    public void setParticipations(Set<SurveyPanelistParticipation> participations) {
+        this.participations = participations;
     }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/SurveyPanelistParticipation.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/SurveyPanelistParticipation.java
@@ -1,0 +1,65 @@
+package uy.com.equipos.panelmanagement.data;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Entity
+public class SurveyPanelistParticipation extends AbstractEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "survey_id")
+    @NotNull
+    private Survey survey;
+
+    @ManyToOne
+    @JoinColumn(name = "panelist_id")
+    @NotNull
+    private Panelist panelist;
+
+    private LocalDate dateIncluded;
+    private LocalDate dateSent;
+    private boolean completed;
+
+    public Survey getSurvey() {
+        return survey;
+    }
+
+    public void setSurvey(Survey survey) {
+        this.survey = survey;
+    }
+
+    public Panelist getPanelist() {
+        return panelist;
+    }
+
+    public void setPanelist(Panelist panelist) {
+        this.panelist = panelist;
+    }
+
+    public LocalDate getDateIncluded() {
+        return dateIncluded;
+    }
+
+    public void setDateIncluded(LocalDate dateIncluded) {
+        this.dateIncluded = dateIncluded;
+    }
+
+    public LocalDate getDateSent() {
+        return dateSent;
+    }
+
+    public void setDateSent(LocalDate dateSent) {
+        this.dateSent = dateSent;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/SurveyPanelistParticipationRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/SurveyPanelistParticipationRepository.java
@@ -1,0 +1,11 @@
+package uy.com.equipos.panelmanagement.data;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface SurveyPanelistParticipationRepository
+        extends
+            JpaRepository<SurveyPanelistParticipation, Long>,
+            JpaSpecificationExecutor<SurveyPanelistParticipation> {
+
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/SurveyRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/SurveyRepository.java
@@ -10,11 +10,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long>, JpaSpecificationExecutor<Survey> {
 
+    // Ya no se necesita findByIdWithPanelists, se usará la carga EAGER/LAZY definida en la entidad
+    // o se creará un método específico para cargar participaciones si es necesario.
     // Option 1: Using @Query with JOIN FETCH
-    @Query("SELECT s FROM Survey s LEFT JOIN FETCH s.panelists WHERE s.id = :id")
-    Optional<Survey> findByIdWithPanelists(@Param("id") Long id);
+    // @Query("SELECT s FROM Survey s LEFT JOIN FETCH s.participations WHERE s.id = :id")
+    // Optional<Survey> findByIdWithParticipations(@Param("id") Long id);
 
     // Option 2: Using @EntityGraph (alternative, choose one)
-    // @EntityGraph(attributePaths = { "panelists" })
-    // Optional<Survey> findById(Long id); // If using this, you'd rename the existing findById or rely on method override
+    // @EntityGraph(attributePaths = { "participations" })
+    // Optional<Survey> findById(Long id);
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
@@ -34,15 +34,18 @@ public class PanelistService {
         Optional<Panelist> panelistOptional = repository.findById(id);
         panelistOptional.ifPresent(panelist -> {
             Hibernate.initialize(panelist.getPropertyValues());
-            Hibernate.initialize(panelist.getSurveys()); // Initialize surveys as well
+            Hibernate.initialize(panelist.getParticipations()); // Actualizado a participations
         });
         return panelistOptional;
     }
 
-    @Transactional(readOnly = true)
-    public Optional<Panelist> findByIdWithSurveys(Long id) {
-        return repository.findByIdWithSurveys(id);
-    }
+    // El método findByIdWithSurveys ya no es necesario o debe ser reemplazado
+    // por una lógica que cargue las participaciones si se requiere.
+    // Por ahora, lo comentamos o eliminamos.
+    // @Transactional(readOnly = true)
+    // public Optional<Panelist> findByIdWithParticipations(Long id) {
+    //    return repository.findByIdWithParticipations(id);
+    // }
 
     public Panelist save(Panelist entity) {
         return repository.save(entity);

--- a/src/main/java/uy/com/equipos/panelmanagement/services/SurveyPanelistParticipationService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/SurveyPanelistParticipationService.java
@@ -1,0 +1,53 @@
+package uy.com.equipos.panelmanagement.services;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import uy.com.equipos.panelmanagement.data.SurveyPanelistParticipation;
+import uy.com.equipos.panelmanagement.data.SurveyPanelistParticipationRepository;
+
+@Service
+public class SurveyPanelistParticipationService {
+
+    private final SurveyPanelistParticipationRepository repository;
+
+    public SurveyPanelistParticipationService(SurveyPanelistParticipationRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<SurveyPanelistParticipation> get(Long id) {
+        return repository.findById(id);
+    }
+
+    public SurveyPanelistParticipation save(SurveyPanelistParticipation entity) {
+        return repository.save(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Page<SurveyPanelistParticipation> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Page<SurveyPanelistParticipation> list(Pageable pageable, Specification<SurveyPanelistParticipation> filter) {
+        return repository.findAll(filter, pageable);
+    }
+
+    public List<SurveyPanelistParticipation> findBySurveyId(Long surveyId) {
+        // Esto requeriría un método personalizado en el repositorio si no se usa Specification
+        // Por ejemplo, en SurveyPanelistParticipationRepository:
+        // List<SurveyPanelistParticipation> findBySurveyId(Long surveyId);
+        // O usar Specification:
+        return repository.findAll((root, query, cb) -> cb.equal(root.get("survey").get("id"), surveyId));
+    }
+
+    public int count() {
+        return (int) repository.count();
+    }
+
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/services/SurveyService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/SurveyService.java
@@ -26,9 +26,12 @@ public class SurveyService {
         return repository.findById(id);
     }
 
-    public Optional<Survey> getWithPanelists(Long id) {
-        return repository.findByIdWithPanelists(id);
-    }
+    // El método getWithPanelists ya no es necesario o debe ser reemplazado
+    // por una lógica que cargue las participaciones si se requiere.
+    // Por ahora, lo comentamos o eliminamos.
+    // public Optional<Survey> getWithPanelists(Long id) {
+    //    return repository.findByIdWithPanelists(id);
+    // }
 
     public Survey save(Survey entity) {
         return repository.save(entity);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -713,3 +713,12 @@ UPDATE PanelistProperty SET type = 'CODIGO' WHERE type = 'Codigo';
 -- Note: If the PanelistPropertyCode table or PanelistProperty.codes column
 -- needs initial data related to existing 'Codigo' type properties,
 -- those inserts/updates would also go here. For now, we are only converting types.
+
+-- Eliminar datos de la tabla survey_panelist (ya no existe)
+-- No es necesario eliminar explícitamente ya que la tabla se elimina en schema.sql
+
+-- Agregar datos de ejemplo para survey_panelist_participation (opcional)
+-- Ejemplo:
+-- insert into survey_panelist_participation(version, survey_id, panelist_id, date_included, date_sent, completed) values (1, 1, 1, '2023-01-01', '2023-01-02', false);
+-- insert into survey_panelist_participation(version, survey_id, panelist_id, date_included, date_sent, completed) values (1, 1, 2, '2023-01-01', null, false);
+-- insert into survey_panelist_participation(version, survey_id, panelist_id, date_included, date_sent, completed) values (1, 2, 1, '2023-02-01', '2023-02-05', true);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,3 +18,20 @@ ALTER TABLE survey ADD COLUMN tool VARCHAR(255) NOT NULL DEFAULT 'SURVEYTOGO';
 
 -- Update existing rows to have a default value if necessary (optional, depending on policy)
 -- UPDATE survey SET tool = 'SURVEYTOGO' WHERE tool IS NULL;
+
+-- Eliminar la tabla survey_panelist (ya no es necesaria)
+DROP TABLE IF EXISTS survey_panelist;
+
+-- Crear la tabla survey_panelist_participation
+CREATE TABLE IF NOT EXISTS survey_panelist_participation (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    version BIGINT,
+    survey_id BIGINT,
+    panelist_id BIGINT,
+    date_included DATE,
+    date_sent DATE,
+    completed BOOLEAN,
+    PRIMARY KEY (id),
+    FOREIGN KEY (survey_id) REFERENCES survey(id),
+    FOREIGN KEY (panelist_id) REFERENCES panelist(id)
+);


### PR DESCRIPTION
- Created SurveyPanelistParticipation entity with dateIncluded, dateSent, and completed attributes.
- Modified Survey and Panelist entities to use OneToMany with SurveyPanelistParticipation.
- Updated schema.sql: dropped survey_panelist, created survey_panelist_participation table.
- Updated data.sql with examples for the new table.
- Created SurveyPanelistParticipationRepository.
- Updated SurveyService, PanelistService, SurveyRepository, and PanelistRepository to reflect new relationships.
- Updated SurveysView to use SurveyPanelistParticipation and its service for displaying participations.
- Created SurveyPanelistParticipationService.