### PR TITLE
Fix: Add missing survey-related methods to Panelist and PanelistService

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
@@ -3,6 +3,10 @@ package uy.com.equipos.panelmanagement.data;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors; // Added for stream operations
+
+import uy.com.equipos.panelmanagement.data.Survey; // Added to reference Survey type
+
 // PanelistPropertyValue is in the same package
 
 import jakarta.persistence.CascadeType;
@@ -88,5 +92,19 @@ public class Panelist extends AbstractEntity {
 
     public void setParticipations(Set<SurveyPanelistParticipation> participations) {
         this.participations = participations;
+    }
+
+    /**
+     * Gets the set of surveys this panelist has participated in.
+     * This is derived from the 'participations' collection.
+     * @return A Set of Survey objects. Returns an empty set if participations is null or empty.
+     */
+    public Set<Survey> getSurveys() {
+        if (this.participations == null) {
+            return new HashSet<>();
+        }
+        return this.participations.stream()
+                                 .map(SurveyPanelistParticipation::getSurvey)
+                                 .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
@@ -47,6 +47,13 @@ public class PanelistService {
     //    return repository.findByIdWithParticipations(id);
     // }
 
+    @Transactional(readOnly = true)
+    public Optional<Panelist> findByIdWithSurveys(Long id) {
+        // The existing get() method already initializes participations,
+        // which is needed for getSurveys() to work correctly.
+        return get(id);
+    }
+
     public Panelist save(Panelist entity) {
         return repository.save(entity);
     }


### PR DESCRIPTION
- Added `getSurveys()` to `Panelist.java` to retrieve a set of `Survey` objects from the `participations` collection.
- Added `findByIdWithSurveys(Long id)` to `PanelistService.java` to fetch a panelist with initialized survey participations.

These changes resolve undefined method errors in `PanelistsView.java` when displaying surveys a panelist has participated in.