### PR TITLE
Fix: Resolve LazyInitializationException in SurveysView

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/SurveyRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/SurveyRepository.java
@@ -13,8 +13,8 @@ public interface SurveyRepository extends JpaRepository<Survey, Long>, JpaSpecif
     // Ya no se necesita findByIdWithPanelists, se usará la carga EAGER/LAZY definida en la entidad
     // o se creará un método específico para cargar participaciones si es necesario.
     // Option 1: Using @Query with JOIN FETCH
-    // @Query("SELECT s FROM Survey s LEFT JOIN FETCH s.participations WHERE s.id = :id")
-    // Optional<Survey> findByIdWithParticipations(@Param("id") Long id);
+    @Query("SELECT s FROM Survey s LEFT JOIN FETCH s.participations WHERE s.id = :id")
+    Optional<Survey> findByIdWithParticipations(@Param("id") Long id);
 
     // Option 2: Using @EntityGraph (alternative, choose one)
     // @EntityGraph(attributePaths = { "participations" })

--- a/src/main/java/uy/com/equipos/panelmanagement/services/SurveyService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/SurveyService.java
@@ -33,6 +33,10 @@ public class SurveyService {
     //    return repository.findByIdWithPanelists(id);
     // }
 
+    public Optional<Survey> getWithParticipations(Long id) {
+        return repository.findByIdWithParticipations(id);
+    }
+
     public Survey save(Survey entity) {
         return repository.save(entity);
     }

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -319,7 +319,7 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         // Para ser explícitos, podríamos hacer:
         // List<SurveyPanelistParticipation> participations = participationService.findBySurveyId(this.survey.getId());
         // O, si la entidad Survey ya tiene las participaciones (por carga EAGER o JOIN FETCH previo):
-        Survey currentSurvey = surveyService.get(this.survey.getId()).orElse(null);
+        Survey currentSurvey = surveyService.getWithParticipations(this.survey.getId()).orElse(null); // Changed to getWithParticipations
         if (currentSurvey == null || currentSurvey.getParticipations() == null || currentSurvey.getParticipations().isEmpty()) {
             Notification.show("No hay participaciones para esta encuesta.", 3000, Notification.Position.MIDDLE);
             return;


### PR DESCRIPTION
- Modified `SurveyRepository` to include a method `findByIdWithParticipations` that uses JOIN FETCH to eagerly load the `participations` collection for a `Survey`.
- Added `getWithParticipations` method to `SurveyService` to call the new repository method.
- Updated `SurveysView.openParticipantsDialog` to use `surveyService.getWithParticipations` ensuring the `participations` collection is initialized before access.

This prevents the `LazyInitializationException` that occurred when trying to access the lazily-loaded `participations` collection outside of an active Hibernate session.