### PR TITLE
Add MessageTask entity and 'Enviar encuestas' functionality

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/JobType.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/JobType.java
@@ -1,0 +1,6 @@
+package uy.com.equipos.panelmanagement.data;
+
+public enum JobType {
+    ALCHEMER_INVITE,
+    ALCHEMER_REMINDER
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/MessageTask.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/MessageTask.java
@@ -1,0 +1,74 @@
+package uy.com.equipos.panelmanagement.data;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Entity
+public class MessageTask extends AbstractEntity {
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private JobType jobType;
+
+    @NotNull
+    private LocalDateTime created;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private MessageTaskStatus status;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "survey_id")
+    private Survey survey;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "panelist_id")
+    private Panelist panelist;
+
+    public JobType getJobType() {
+        return jobType;
+    }
+
+    public void setJobType(JobType jobType) {
+        this.jobType = jobType;
+    }
+
+    public LocalDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(LocalDateTime created) {
+        this.created = created;
+    }
+
+    public MessageTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(MessageTaskStatus status) {
+        this.status = status;
+    }
+
+    public Survey getSurvey() {
+        return survey;
+    }
+
+    public void setSurvey(Survey survey) {
+        this.survey = survey;
+    }
+
+    public Panelist getPanelist() {
+        return panelist;
+    }
+
+    public void setPanelist(Panelist panelist) {
+        this.panelist = panelist;
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/MessageTaskRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/MessageTaskRepository.java
@@ -1,0 +1,7 @@
+package uy.com.equipos.panelmanagement.data;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface MessageTaskRepository extends JpaRepository<MessageTask, Long>, JpaSpecificationExecutor<MessageTask> {
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/MessageTaskStatus.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/MessageTaskStatus.java
@@ -1,0 +1,7 @@
+package uy.com.equipos.panelmanagement.data;
+
+public enum MessageTaskStatus {
+    PENDING,
+    DONE,
+    ERROR
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
@@ -107,4 +107,15 @@ public class Panelist extends AbstractEntity {
                                  .map(SurveyPanelistParticipation::getSurvey)
                                  .collect(Collectors.toSet());
     }
+
+    @OneToMany(mappedBy = "panelist", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<MessageTask> messageTasks = new HashSet<>();
+
+    public Set<MessageTask> getMessageTasks() {
+        return messageTasks;
+    }
+
+    public void setMessageTasks(Set<MessageTask> messageTasks) {
+        this.messageTasks = messageTasks;
+    }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/Survey.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Survey.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
+import jakarta.persistence.CascadeType;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
@@ -57,5 +58,16 @@ public class Survey extends AbstractEntity {
 
     public void setParticipations(Set<SurveyPanelistParticipation> participations) {
         this.participations = participations;
+    }
+
+    @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<MessageTask> messageTasks = new HashSet<>();
+
+    public Set<MessageTask> getMessageTasks() {
+        return messageTasks;
+    }
+
+    public void setMessageTasks(Set<MessageTask> messageTasks) {
+        this.messageTasks = messageTasks;
     }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/MessageTaskService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/MessageTaskService.java
@@ -1,0 +1,38 @@
+package uy.com.equipos.panelmanagement.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uy.com.equipos.panelmanagement.data.MessageTask;
+import uy.com.equipos.panelmanagement.data.MessageTaskRepository;
+
+@Service
+public class MessageTaskService {
+
+    private final MessageTaskRepository repository;
+
+    @Autowired
+    public MessageTaskService(MessageTaskRepository repository) {
+        this.repository = repository;
+    }
+
+    public MessageTask save(MessageTask messageTask) {
+        return repository.save(messageTask);
+    }
+
+    // Optional: Add other common service methods like list, get, delete if needed for future use.
+    // public Optional<MessageTask> get(Long id) {
+    //     return repository.findById(id);
+    // }
+
+    // public void delete(Long id) {
+    //     repository.deleteById(id);
+    // }
+
+    // public Page<MessageTask> list(Pageable pageable) {
+    //     return repository.findAll(pageable);
+    // }
+
+    // public Page<MessageTask> list(Pageable pageable, Specification<MessageTask> filter) {
+    //     return repository.findAll(filter, pageable);
+    // }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -28,10 +28,14 @@ import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.BeanValidationBinder;
 import java.util.Collections;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import uy.com.equipos.panelmanagement.data.Panelist;
+import uy.com.equipos.panelmanagement.data.JobType;
+import uy.com.equipos.panelmanagement.data.MessageTask;
+import uy.com.equipos.panelmanagement.data.MessageTaskStatus;
 import com.vaadin.flow.data.binder.ValidationException;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
@@ -49,6 +53,7 @@ import uy.com.equipos.panelmanagement.data.SurveyPanelistParticipation; // Nueva
 import uy.com.equipos.panelmanagement.services.PanelService;
 import uy.com.equipos.panelmanagement.services.SurveyService;
 import uy.com.equipos.panelmanagement.services.SurveyPanelistParticipationService; // Nueva importación
+import uy.com.equipos.panelmanagement.services.MessageTaskService; // Nueva importación
 
 @PageTitle("Encuestas")
 @Route("surveys/:surveyID?/:action?(edit)")
@@ -79,6 +84,7 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 	private Button nuevaEncuestaButton;
     private Button viewParticipantsButton;
     private Button sortearPanelistasButton; // New button for drawing panelists
+    private Button sendSurveysButton; // New button for sending surveys
 
 	private final BeanValidationBinder<Survey> binder;
 
@@ -87,11 +93,16 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 	private final SurveyService surveyService;
     private final SurveyPanelistParticipationService participationService; // Nuevo servicio
     private final PanelService panelService; // Service for Panel entities
+    private final MessageTaskService messageTaskService; // Service for MessageTask entities
 
-	public SurveysView(SurveyService surveyService, SurveyPanelistParticipationService participationService, PanelService panelService) {
+	public SurveysView(SurveyService surveyService,
+                         SurveyPanelistParticipationService participationService,
+                         PanelService panelService,
+                         MessageTaskService messageTaskService) {
 		this.surveyService = surveyService;
         this.participationService = participationService; // Inyectar nuevo servicio
         this.panelService = panelService; // Inyectar PanelService
+        this.messageTaskService = messageTaskService; // Inyectar MessageTaskService
 		addClassNames("surveys-view");
 
 		// Initialize deleteButton EARLIER
@@ -104,6 +115,9 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 
         sortearPanelistasButton = new Button("Sortear participantes");
         sortearPanelistasButton.addClickListener(e -> openSortearPanelistasDialog());
+
+        sendSurveysButton = new Button("Enviar encuestas");
+        sendSurveysButton.addClickListener(e -> sendSurveysAction());
 
 		// Configurar columnas del Grid PRIMERO
 		grid.addColumn(Survey::getName).setHeader("Nombre").setKey("name").setAutoWidth(true);
@@ -260,7 +274,7 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 		tool = new ComboBox<>("Herramienta");
 		tool.setItems(Tool.values());
 		tool.setItemLabelGenerator(Tool::name); 
-		formLayout.add(name, initDate, link, tool, viewParticipantsButton,sortearPanelistasButton);
+		formLayout.add(name, initDate, link, tool, viewParticipantsButton, sortearPanelistasButton, sendSurveysButton);
 
 
 		editorDiv.add(formLayout);
@@ -309,6 +323,9 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         if (sortearPanelistasButton != null) {
             sortearPanelistasButton.setEnabled(value != null && value.getId() != null);
         }
+        if (sendSurveysButton != null) {
+            sendSurveysButton.setEnabled(value != null && value.getId() != null);
+        }
 	}
 
 	private void clearForm() {
@@ -325,7 +342,47 @@ public class SurveysView extends Div implements BeforeEnterObserver {
         if (sortearPanelistasButton != null) {
             sortearPanelistasButton.setEnabled(false);
         }
+        if (sendSurveysButton != null) {
+            sendSurveysButton.setEnabled(false);
+        }
 	}
+
+    private void sendSurveysAction() {
+        if (this.survey == null || this.survey.getId() == null) {
+            Notification.show("Por favor, seleccione una encuesta.", 3000, Notification.Position.MIDDLE);
+            return;
+        }
+
+        Optional<Survey> surveyOpt = surveyService.getWithParticipations(this.survey.getId());
+        if (surveyOpt.isEmpty()) {
+            Notification.show("Encuesta no encontrada.", 3000, Notification.Position.MIDDLE);
+            return;
+        }
+
+        Survey currentSurveyWithParticipations = surveyOpt.get();
+        Set<SurveyPanelistParticipation> participations = currentSurveyWithParticipations.getParticipations();
+
+        if (participations == null || participations.isEmpty()) {
+            Notification.show("No hay panelistas asignados a esta encuesta.", 3000, Notification.Position.MIDDLE);
+            return;
+        }
+
+        int tasksCreated = 0;
+        for (SurveyPanelistParticipation participation : participations) {
+            Panelist panelist = participation.getPanelist();
+            if (panelist != null) {
+                MessageTask mt = new MessageTask();
+                mt.setJobType(JobType.ALCHEMER_INVITE);
+                mt.setCreated(LocalDateTime.now());
+                mt.setStatus(MessageTaskStatus.PENDING);
+                mt.setSurvey(currentSurveyWithParticipations);
+                mt.setPanelist(panelist);
+                messageTaskService.save(mt);
+                tasksCreated++;
+            }
+        }
+        Notification.show(tasksCreated + " tareas de mensaje creadas para los panelistas.", 3000, Notification.Position.BOTTOM_START);
+    }
 
     private void openSortearPanelistasDialog() {
         if (this.survey == null || this.survey.getId() == null) {


### PR DESCRIPTION
- Defined JobType and MessageTaskStatus enums.
- Created MessageTask entity with relationships to Survey and Panelist.
- Updated Survey and Panelist entities with OneToMany relationships to MessageTask.
- Created MessageTaskRepository and MessageTaskService.
- Added 'Enviar encuestas' button to SurveysView.
- Implemented logic to create MessageTask entries for each panelist associated with the selected survey when the button is clicked.
- MessageTasks are created with JobType 'ALCHEMER_INVITE', current timestamp for 'created', and status 'PENDING'.