### PR TITLE
Refactor MessageTask to use SurveyPanelistParticipation

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/MessageTask.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/MessageTask.java
@@ -25,13 +25,8 @@ public class MessageTask extends AbstractEntity {
 
     @NotNull
     @ManyToOne
-    @JoinColumn(name = "survey_id")
-    private Survey survey;
-
-    @NotNull
-    @ManyToOne
-    @JoinColumn(name = "panelist_id")
-    private Panelist panelist;
+    @JoinColumn(name = "survey_panelist_participation_id")
+    private SurveyPanelistParticipation surveyPanelistParticipation;
 
     public JobType getJobType() {
         return jobType;
@@ -57,19 +52,11 @@ public class MessageTask extends AbstractEntity {
         this.status = status;
     }
 
-    public Survey getSurvey() {
-        return survey;
+    public SurveyPanelistParticipation getSurveyPanelistParticipation() {
+        return surveyPanelistParticipation;
     }
 
-    public void setSurvey(Survey survey) {
-        this.survey = survey;
-    }
-
-    public Panelist getPanelist() {
-        return panelist;
-    }
-
-    public void setPanelist(Panelist panelist) {
-        this.panelist = panelist;
+    public void setSurveyPanelistParticipation(SurveyPanelistParticipation surveyPanelistParticipation) {
+        this.surveyPanelistParticipation = surveyPanelistParticipation;
     }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Panelist.java
@@ -108,14 +108,18 @@ public class Panelist extends AbstractEntity {
                                  .collect(Collectors.toSet());
     }
 
-    @OneToMany(mappedBy = "panelist", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<MessageTask> messageTasks = new HashSet<>();
+    // The relationship from Panelist to MessageTask is now indirect via SurveyPanelistParticipation.
+    // Similar to the Survey entity, direct access to MessageTasks from Panelist might be re-evaluated.
+    // Access would typically be: panelist.getParticipations().stream().flatMap(p -> p.getMessageTasks().stream()).collect(Collectors.toSet());
+    // Commenting out for now.
+    // @OneToMany(mappedBy = "panelist", cascade = CascadeType.ALL, orphanRemoval = true)
+    // private Set<MessageTask> messageTasks = new HashSet<>();
 
-    public Set<MessageTask> getMessageTasks() {
-        return messageTasks;
-    }
+    // public Set<MessageTask> getMessageTasks() {
+    //     return messageTasks;
+    // }
 
-    public void setMessageTasks(Set<MessageTask> messageTasks) {
-        this.messageTasks = messageTasks;
-    }
+    // public void setMessageTasks(Set<MessageTask> messageTasks) {
+    //     this.messageTasks = messageTasks;
+    // }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/Survey.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Survey.java
@@ -60,14 +60,19 @@ public class Survey extends AbstractEntity {
         this.participations = participations;
     }
 
-    @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<MessageTask> messageTasks = new HashSet<>();
+    // The relationship from Survey to MessageTask is now indirect via SurveyPanelistParticipation.
+    // If you need to access MessageTasks related to a Survey, you would typically go through its participations.
+    // For example, survey.getParticipations().stream().flatMap(p -> p.getMessageTasks().stream()).collect(Collectors.toSet());
+    // Therefore, the direct @OneToMany MessageTask collection here might be removed or re-evaluated.
+    // For now, we'll comment it out as it's no longer directly mapped by "survey" in MessageTask.
+    // @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+    // private Set<MessageTask> messageTasks = new HashSet<>();
 
-    public Set<MessageTask> getMessageTasks() {
-        return messageTasks;
-    }
+    // public Set<MessageTask> getMessageTasks() {
+    //     return messageTasks;
+    // }
 
-    public void setMessageTasks(Set<MessageTask> messageTasks) {
-        this.messageTasks = messageTasks;
-    }
+    // public void setMessageTasks(Set<MessageTask> messageTasks) {
+    //     this.messageTasks = messageTasks;
+    // }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/data/SurveyPanelistParticipation.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/SurveyPanelistParticipation.java
@@ -5,6 +5,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.OneToMany;
+
 
 @Entity
 public class SurveyPanelistParticipation extends AbstractEntity {
@@ -61,5 +66,16 @@ public class SurveyPanelistParticipation extends AbstractEntity {
 
     public void setCompleted(boolean completed) {
         this.completed = completed;
+    }
+
+    @OneToMany(mappedBy = "surveyPanelistParticipation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<MessageTask> messageTasks = new HashSet<>();
+
+    public Set<MessageTask> getMessageTasks() {
+        return messageTasks;
+    }
+
+    public void setMessageTasks(Set<MessageTask> messageTasks) {
+        this.messageTasks = messageTasks;
     }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -379,14 +379,14 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 
         int tasksCreated = 0;
         for (SurveyPanelistParticipation participation : participations) {
-            Panelist panelist = participation.getPanelist();
-            if (panelist != null) {
+            // Panelist panelist = participation.getPanelist(); // No longer needed directly for MessageTask
+            // if (panelist != null) { // Check if participation itself is valid if necessary
+            if (participation != null && participation.getPanelist() != null) { // Ensure participation and its panelist are not null
                 MessageTask mt = new MessageTask();
                 mt.setJobType(JobType.ALCHEMER_INVITE);
                 mt.setCreated(LocalDateTime.now());
                 mt.setStatus(MessageTaskStatus.PENDING);
-                mt.setSurvey(currentSurveyWithParticipations);
-                mt.setPanelist(panelist);
+                mt.setSurveyPanelistParticipation(participation); // Set the participation
                 messageTaskService.save(mt);
                 tasksCreated++;
             }
@@ -416,14 +416,14 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 
         int tasksCreated = 0;
         for (SurveyPanelistParticipation participation : participations) {
-            Panelist panelist = participation.getPanelist();
-            if (panelist != null) {
+            // Panelist panelist = participation.getPanelist(); // No longer needed directly for MessageTask
+            // if (panelist != null) { // Check if participation itself is valid if necessary
+            if (participation != null && participation.getPanelist() != null) { // Ensure participation and its panelist are not null
                 MessageTask mt = new MessageTask();
                 mt.setJobType(JobType.ALCHEMER_REMINDER);
                 mt.setCreated(LocalDateTime.now());
                 mt.setStatus(MessageTaskStatus.PENDING); // Assuming PENDING exists
-                mt.setSurvey(currentSurveyWithParticipations);
-                mt.setPanelist(panelist);
+                mt.setSurveyPanelistParticipation(participation); // Set the participation
                 messageTaskService.save(mt);
                 tasksCreated++;
             }


### PR DESCRIPTION
- Modified MessageTask entity to replace direct relationships with Survey and Panelist entities with a single relationship to SurveyPanelistParticipation.
- Updated SurveysView to correctly create MessageTask instances using the new relationship when sending surveys and reminders.
- Adjusted Survey and Panelist entities to remove the now-obsolete direct relationship to MessageTask.
- Added the inverse OneToMany relationship from SurveyPanelistParticipation to MessageTask.