### PR TITLE
Refactor: Update Alchemer ID extraction for new URL format

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/scheduler/AlchemerInviteSender.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/scheduler/AlchemerInviteSender.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,8 +147,17 @@ public class AlchemerInviteSender {
 	}
 
 	private String getContactId(String surveyLinkOrSurveyId, String email) {
-		String extractedId = extractCampaignId(surveyLinkOrSurveyId); // Assumed to be survey_id and used as campaign_id
-																		// for default campaign
+		String surveyId = extractSurveyId(surveyLinkOrSurveyId);
+		String campaignId = extractCampaignId(surveyLinkOrSurveyId);
+
+		if (surveyId == null) {
+			log.error("getContactId: Could not extract Survey ID from input: {}", surveyLinkOrSurveyId);
+			return null;
+		}
+		if (campaignId == null) {
+			log.warn("getContactId: Campaign ID could not be extracted from input: {}. Defaulting to Survey ID for campaign context.", surveyLinkOrSurveyId);
+			campaignId = surveyId; // Default to surveyId if campaignId is not specifically found
+		}
 
 		// V5 SurveyContact API: GET
 		// /v5/survey/{survey_id}/surveycampaign/{campaign_id}/surveycontact
@@ -154,7 +165,7 @@ public class AlchemerInviteSender {
 		// ?filter[field][0]=email_address&filter[operator][0]==&filter[value][0]={email}
 
 		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ALCHEMER_API_BASE_URL)
-				.pathSegment("v5", "survey", extractedId, "surveycampaign", extractedId, "surveycontact")
+				.pathSegment("v5", "survey", surveyId, "surveycampaign", campaignId, "surveycontact")
 				.queryParam("filter[field][0]", "email_address").queryParam("filter[operator][0]", "==")
 				.queryParam("filter[value][0]", email) // email value will be URL encoded by the builder
 				.queryParam("api_token", apiToken).queryParam("api_token_secret", apiTokenSecret);
@@ -172,92 +183,84 @@ public class AlchemerInviteSender {
 					if (dataObj instanceof List) {
 						List<Map<String, Object>> dataList = (List<Map<String, Object>>) dataObj;
 						if (!dataList.isEmpty()) {
-							// Assuming the first contact found is the correct one
 							Map<String, Object> contactData = dataList.get(0);
-							log.info("Contacto encontrado para email {}: ID {}", email, contactData.get("id"));
+							log.info("Contacto encontrado para email {}: ID {} (SurveyID: {}, CampaignID: {})", email, contactData.get("id"), surveyId, campaignId);
 							return String.valueOf(contactData.get("id"));
 						} else {
-							log.info("Contacto con email {} no encontrado en campaña {} (survey_id {}) (lista vacía).",
-									email, extractedId, extractedId);
+							log.info("Contacto con email {} no encontrado en SurveyID: {}, CampaignID: {} (lista vacía).",
+									email, surveyId, campaignId);
 						}
 					} else if (dataObj instanceof Map) {
-						// Less common for list endpoints, but handle if API returns single object if
-						// only one found
 						Map<String, Object> contactData = (Map<String, Object>) dataObj;
 						if (contactData.containsKey("id")
 								&& email.equalsIgnoreCase(String.valueOf(contactData.get("email_address")))) {
-							log.info("Contacto encontrado para email {}: ID {}", email, contactData.get("id"));
+							log.info("Contacto encontrado para email {}: ID {} (SurveyID: {}, CampaignID: {})", email, contactData.get("id"), surveyId, campaignId);
 							return String.valueOf(contactData.get("id"));
 						}
 					} else {
 						log.info(
-								"Contacto con email {} no encontrado en campaña {} (survey_id {}) (formato de 'data' inesperado). Respuesta: {}",
-								email, extractedId, extractedId, response.getBody());
+								"Contacto con email {} no encontrado en SurveyID: {}, CampaignID: {} (formato de 'data' inesperado). Respuesta: {}",
+								email, surveyId, campaignId, response.getBody());
 					}
 				} else {
 					log.warn(
-							"API call para getContactId no fue exitosa (result_ok=false) para email {}. Campaña/Survey ID {}. Respuesta: {}",
-							email, extractedId, response.getBody());
+							"API call para getContactId no fue exitosa (result_ok=false) for email {}. SurveyID: {}, CampaignID: {}. Respuesta: {}",
+							email, surveyId, campaignId, response.getBody());
 				}
 			} else {
-				log.warn("Respuesta no OK del servidor ({}) al buscar contacto {} en campaña {} (survey_id {}).",
-						response.getStatusCode(), email, extractedId, extractedId);
+				log.warn("Respuesta no OK del servidor ({}) al buscar contacto {} en SurveyID: {}, CampaignID: {}.",
+						response.getStatusCode(), email, surveyId, campaignId);
 			}
 		} catch (HttpClientErrorException e) {
 			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
-				log.info("Contacto {} no encontrado (HTTP 404) en campaña {} (survey_id {}).", email, extractedId,
-						extractedId);
+				log.info("Contacto {} no encontrado (HTTP 404) en SurveyID: {}, CampaignID: {}.", email, surveyId,
+						campaignId);
 			} else {
 				log.error(
-						"Error (HttpClientErrorException) al verificar contacto {} en campaña {} (survey_id {}): {} - {}",
-						email, extractedId, extractedId, e.getStatusCode(), e.getResponseBodyAsString());
+						"Error (HttpClientErrorException) al verificar contacto {} en SurveyID: {}, CampaignID: {}: {} - {}",
+						email, surveyId, campaignId, e.getStatusCode(), e.getResponseBodyAsString());
 			}
 		} catch (org.springframework.web.client.RestClientException e) {
-			log.error("Error (RestClientException) al verificar contacto {} en campaña {} (survey_id {}): {}", email,
-					extractedId, extractedId, e.getMessage(), e);
+			log.error("Error (RestClientException) al verificar contacto {} en SurveyID: {}, CampaignID: {}: {}", email,
+					surveyId, campaignId, e.getMessage(), e);
 		}
 		return null;
 	}
 
 	private String addContactToCampaign(String surveyLinkOrSurveyId, String email, String firstName, String lastName) {
-		String extractedId = extractCampaignId(surveyLinkOrSurveyId); // Assumed survey_id, used as campaign_id
+		String surveyId = extractSurveyId(surveyLinkOrSurveyId);
+		String campaignId = extractCampaignId(surveyLinkOrSurveyId);
+
+		if (surveyId == null) {
+			log.error("addContactToCampaign: Could not extract Survey ID from input: {}", surveyLinkOrSurveyId);
+			return null;
+		}
+		if (campaignId == null) {
+			log.warn("addContactToCampaign: Campaign ID could not be extracted from input: {}. Defaulting to Survey ID for campaign context.", surveyLinkOrSurveyId);
+			campaignId = surveyId; // Default to surveyId
+		}
 
 		// V5 SurveyContact CREATE: PUT
 		// /v5/survey/{s_id}/surveycampaign/{c_id}/surveycontact
 		// Contact data as URL parameters.
 		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ALCHEMER_API_BASE_URL)
-				.pathSegment("v5", "survey", extractedId, "surveycampaign", extractedId, "surveycontact")
+				.pathSegment("v5", "survey", surveyId, "surveycampaign", campaignId, "surveycontact")
 				.queryParam("api_token", apiToken).queryParam("api_token_secret", apiTokenSecret)
 				.queryParam("email_address", email) // Parameter names from Alchemer docs
 				.queryParam("first_name", firstName).queryParam("last_name", lastName);
-		// The Alchemer documentation for "CREATE CONTACT" for SurveyContact shows:
-		// .../surveycontact/?_method=PUT&email_address=...
-		// This implies that even if we make a PUT request, they might still expect
-		// _method=PUT.
-		// However, this is usually for clients that can't make true PUT requests.
-		// For RestTemplate, a direct PUT should be fine. If issues arise, adding
-		// _method=PUT can be tested.
-		// builder.queryParam("_method", "PUT"); // Not adding this initially.
 
 		String url = builder.toUriString();
 		log.debug("addContactToCampaign URL: {}", url);
 
 		HttpHeaders headers = new HttpHeaders();
-		// For PUT with all data in URL parameters, the body is typically empty.
-		// Alchemer docs don't specify Content-Type for this, but form-urlencoded is a
-		// safe default if any is needed.
 		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-		HttpEntity<Void> requestEntity = new HttpEntity<>(null, headers); // Empty body
+		HttpEntity<Void> requestEntity = new HttpEntity<>(null, headers);
 
 		try {
-			// Using exchange for PUT to get ResponseEntity back, enabling access to
-			// response body and status.
 			ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.PUT, requestEntity, Map.class);
 
 			if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
 				log.debug("addContactToCampaign response body: {}", response.getBody());
-				// Expected response: { "result_ok": true, "data": { "id": "NEW_CONTACT_ID", ...
-				// } }
 				if (Boolean.TRUE.equals(response.getBody().get("result_ok"))) {
 					Object dataObj = response.getBody().get("data");
 					if (dataObj instanceof Map) {
@@ -265,66 +268,66 @@ public class AlchemerInviteSender {
 						if (dataMap.containsKey("id")) {
 							String newContactId = String.valueOf(dataMap.get("id"));
 							log.info(
-									"Contacto {} agregado/actualizado en campaña {} (survey_id {}). Nuevo ContactID: {}",
-									email, extractedId, extractedId, newContactId);
+									"Contacto {} agregado/actualizado en SurveyID: {}, CampaignID: {}. Nuevo ContactID: {}",
+									email, surveyId, campaignId, newContactId);
 							return newContactId;
 						} else {
 							log.error(
-									"Respuesta OK pero sin ID de contacto al agregar {} a campaña {} (survey_id {}). Respuesta: {}",
-									email, extractedId, extractedId, response.getBody());
+									"Respuesta OK pero sin ID de contacto al agregar {} a SurveyID: {}, CampaignID: {}. Respuesta: {}",
+									email, surveyId, campaignId, response.getBody());
 						}
 					} else {
-						log.error("Formato de 'data' inesperado al agregar contacto {}. Respuesta: {}", email,
-								response.getBody());
+						log.error("Formato de 'data' inesperado al agregar contacto {} (SurveyID: {}, CampaignID: {}). Respuesta: {}",
+								email, surveyId, campaignId, response.getBody());
 					}
 				} else {
-					log.error("Error en la respuesta de Alchemer (result_ok false) al agregar contacto {}: {}", email,
-							response.getBody());
+					log.error("Error en la respuesta de Alchemer (result_ok false) al agregar contacto {} (SurveyID: {}, CampaignID: {}): {}",
+							email, surveyId, campaignId, response.getBody());
 				}
 			} else {
-				log.error("Error del servidor ({}) al agregar contacto {} a campaña {} (survey_id {}). Body: {}",
-						response.getStatusCode(), email, extractedId, extractedId, response.getBody());
+				log.error("Error del servidor ({}) al agregar contacto {} a SurveyID: {}, CampaignID: {}. Body: {}",
+						response.getStatusCode(), email, surveyId, campaignId, response.getBody());
 			}
 		} catch (HttpClientErrorException e) {
-			log.error("Error (HttpClientErrorException) al agregar contacto {} a campaña {} (survey_id {}): {} - {}",
-					email, extractedId, extractedId, e.getStatusCode(), e.getResponseBodyAsString());
+			log.error("Error (HttpClientErrorException) al agregar contacto {} a SurveyID: {}, CampaignID: {}: {} - {}",
+					email, surveyId, campaignId, e.getStatusCode(), e.getResponseBodyAsString());
 		} catch (org.springframework.web.client.RestClientException e) {
-			log.error("Error (RestClientException) al agregar contacto {} a campaña {} (survey_id {}): {}", email,
-					extractedId, extractedId, e.getMessage(), e);
+			log.error("Error (RestClientException) al agregar contacto {} a SurveyID: {}, CampaignID: {}: {}", email,
+					surveyId, campaignId, e.getMessage(), e);
 		}
 		return null;
 	}
 
 	private boolean sendInvitation(String surveyLinkOrSurveyId, String contactId) {
-		String extractedId = extractCampaignId(surveyLinkOrSurveyId); // Assumed survey_id, also used as campaign_id for
-																		// the default/target campaign
+		String campaignId = extractCampaignId(surveyLinkOrSurveyId);
+		if (campaignId == null) {
+			log.warn("sendInvitation: Campaign ID not found via extractCampaignId for input: {}. Attempting to use Survey ID as fallback.", surveyLinkOrSurveyId);
+			campaignId = extractSurveyId(surveyLinkOrSurveyId);
+			if (campaignId == null) {
+				log.error("sendInvitation: Could not extract any usable ID (Campaign or Survey) from input: {} for sendInvitation", surveyLinkOrSurveyId);
+				return false;
+			}
+		}
 
 		// The current code uses: POST /v5/surveycampaign/{campaignId}/send
 		// with JSON body {"contact_ids": ["CONTACT_ID"]}.
 		// This endpoint is not explicitly detailed in the main V5 object documentation
 		// (SurveyCampaign, EmailMessage).
-		// However, it might be a valid simplified endpoint for sending a default
-		// campaign message.
-		// We will proceed with this structure, ensuring correct IDs and improving
-		// response handling.
-		// If this proves incorrect, a more complex method involving specific
-		// EmailMessage IDs would be needed.
+		// However, it might be a valid simplified endpoint for sending a default campaign message.
+		// We will proceed with this structure, ensuring correct IDs and improving response handling.
 
 		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ALCHEMER_API_BASE_URL)
-				.pathSegment("v5", "surveycampaign", extractedId, "send").queryParam("api_token", apiToken)
+				.pathSegment("v5", "surveycampaign", campaignId, "send").queryParam("api_token", apiToken)
 				.queryParam("api_token_secret", apiTokenSecret);
 
 		String url = builder.toUriString();
 		log.debug("sendInvitation URL: {}", url);
 
 		Map<String, List<String>> requestBody = new HashMap<>();
-		// Sticking with "contact_ids" as per the original code. If issues occur,
-		// "sps_contact_ids" could be an alternative to test based on some Alchemer
-		// examples.
 		requestBody.put("contact_ids", Collections.singletonList(contactId));
 
 		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_JSON); // Body is JSON
+		headers.setContentType(MediaType.APPLICATION_JSON);
 		HttpEntity<Map<String, List<String>>> requestEntity = new HttpEntity<>(requestBody, headers);
 
 		try {
@@ -332,61 +335,98 @@ public class AlchemerInviteSender {
 
 			if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
 				log.debug("sendInvitation response body: {}", response.getBody());
-				// Successful response typically: {"result_ok":true,"data":{"QUEUED":"1"}}
-				// Error example: {"result_ok":false,"message":"No valid contacts selected."}
 				if (Boolean.TRUE.equals(response.getBody().get("result_ok"))) {
-					// Further check data if necessary, e.g., data.QUEUED > 0
-					// For now, result_ok:true is the primary success indicator.
 					log.info(
-							"Invitación para contacto {} en campaña {} (survey_id {}) procesada para envío. Respuesta: {}",
-							contactId, extractedId, extractedId, response.getBody());
+							"Invitación para contacto {} en CampaignID {} procesada para envío. Respuesta: {}",
+							contactId, campaignId, response.getBody());
 					return true;
 				} else {
 					log.error(
-							"Error en la respuesta de Alchemer (result_ok false) al enviar invitación a ContactID {}, CampaignID/SurveyID {}. Respuesta: {}",
-							contactId, extractedId, response.getBody());
+							"Error en la respuesta de Alchemer (result_ok false) al enviar invitación a ContactID {}, CampaignID {}. Respuesta: {}",
+							contactId, campaignId, response.getBody());
 					return false;
 				}
 			} else {
 				log.error(
-						"Error del servidor ({}) al enviar invitación a contacto {} en campaña {} (survey_id {}). Body: {}",
-						response.getStatusCode(), contactId, extractedId, extractedId, response.getBody());
+						"Error del servidor ({}) al enviar invitación a contacto {} en CampaignID {}. Body: {}",
+						response.getStatusCode(), contactId, campaignId, response.getBody());
 			}
 		} catch (HttpClientErrorException e) {
 			log.error(
-					"Error (HttpClientErrorException) al enviar invitación a contacto {} en campaña {} (survey_id {}): {} - {}",
-					contactId, extractedId, extractedId, e.getStatusCode(), e.getResponseBodyAsString());
+					"Error (HttpClientErrorException) al enviar invitación a contacto {} en CampaignID {}: {} - {}",
+					contactId, campaignId, e.getStatusCode(), e.getResponseBodyAsString());
 		} catch (org.springframework.web.client.RestClientException e) {
-			log.error("Error (RestClientException) al enviar invitación a contacto {} en campaña {} (survey_id {}): {}",
-					contactId, extractedId, extractedId, e.getMessage(), e);
+			log.error("Error (RestClientException) al enviar invitación a contacto {} en CampaignID {}: {}",
+					contactId, campaignId, e.getMessage(), e);
 		}
 		return false;
 	}
 
 	private String extractCampaignId(String surveyLink) {
-		// Asume que el surveyLink es el ID de la campaña o contiene el ID.
-		// Para la API de Alchemer, el {link obtenido en paso 3} se refiere al ID de la
-		// encuesta,
-		// y en el contexto de /surveycampaign/{campaign_id}/..., campaign_id es el ID
-		// de la encuesta.
-		// Si el 'link' es una URL completa, se necesitaría una lógica más robusta para
-		// extraer el ID.
-		// Por ahora, asumimos que 'link' es directamente el campaign_id (survey_id).
-		// Ejemplo: si surveyLink es "1234567", se usa "1234567".
-		// Si fuera una URL como "https://app.alchemer.com/s3/1234567/My-Survey", se
-		// necesitaría extraer "1234567".
-		// Esta implementación simple asume que el link es el ID.
-		if (surveyLink != null && surveyLink.contains("/")) {
-			// Intenta extraer el ID si es una URL simple, ej: /s3/1234567 o
-			// /s3/1234567/something
+		if (surveyLink == null) {
+			return null;
+		}
+
+		// Pattern for the new URL format: https://app.alchemer.com/invite/messages/id/SURVEY_ID/link/CAMPAIGN_ID
+		// We are interested in the CAMPAIGN_ID, which is the last numeric part.
+		// Example: "https://app.alchemer.com/invite/messages/id/8367882/link/24099873" -> "24099873"
+		Pattern newUrlPattern = Pattern.compile("/id/(\\d+)/link/(\\d+)$");
+		Matcher matcher = newUrlPattern.matcher(surveyLink);
+
+		if (matcher.find()) {
+			// Group 2 is the CAMPAIGN_ID
+			return matcher.group(2);
+		}
+
+		// Fallback to existing logic for other URL formats or direct IDs
+		if (surveyLink.contains("/")) {
 			String[] parts = surveyLink.split("/");
 			for (int i = parts.length - 1; i >= 0; i--) {
-				if (parts[i].matches("\\d+")) { // Busca una secuencia de dígitos
+				// Check if the part is purely numeric and not empty
+				if (!parts[i].isEmpty() && parts[i].matches("\\d+")) {
 					return parts[i];
 				}
 			}
 		}
-		// Si no es una URL o no se pudo extraer, se asume que es el ID directamente.
-		return surveyLink;
+		// If not a recognized URL pattern or no numeric part found by fallback,
+		// and it's not null and doesn't contain '/', assume it's the ID directly.
+		// Also, if it contained '/' but no numeric part was extracted, it might be a malformed URL
+		// or a direct ID with an accidental slash. If it's numeric, treat as ID.
+		if (surveyLink.matches("\\d+")) {
+		    return surveyLink;
+		}
+		// If no ID could be parsed, return null.
+		return null;
+	}
+
+	private String extractSurveyId(String surveyLink) {
+		if (surveyLink == null) {
+			return null;
+		}
+
+		// 1. Try the new URL pattern: https://app.alchemer.com/invite/messages/id/SURVEY_ID/link/CAMPAIGN_ID
+		// Example: "https://app.alchemer.com/invite/messages/id/8367882/link/24099873" -> "8367882"
+		Pattern newUrlPattern = Pattern.compile("/id/(\\d+)/link/(\\d+)");
+		Matcher newMatcher = newUrlPattern.matcher(surveyLink);
+		if (newMatcher.find()) {
+			return newMatcher.group(1); // SURVEY_ID
+		}
+
+		// 2. Try common older Alchemer URL pattern: e.g., /s3/SURVEY_ID/... or /survey/SURVEY_ID/...
+		// Example: "https://app.alchemer.com/s3/1234567/My-Survey" -> "1234567"
+		Pattern oldUrlPattern = Pattern.compile("/(?:s3|survey)/(\\d+)");
+		Matcher oldMatcher = oldUrlPattern.matcher(surveyLink);
+		if (oldMatcher.find()) {
+			return oldMatcher.group(1); // SURVEY_ID
+		}
+
+		// 3. Check if the surveyLink itself is a plain numeric ID
+		// Example: "8367882" -> "8367882"
+		if (surveyLink.matches("\\d+")) {
+			return surveyLink;
+		}
+
+		// 4. If no pattern matched and it's not a plain number, we couldn't extract a survey ID.
+		return null;
 	}
 }


### PR DESCRIPTION
- Modified `extractCampaignId` to correctly parse campaign IDs from URLs like `.../id/SURVEY_ID/link/CAMPAIGN_ID` and improved fallback logic. The method now returns null if an ID cannot be definitively parsed.
- Added new method `extractSurveyId` to parse survey IDs specifically from the new URL format, with fallbacks for older Alchemer URL patterns (e.g., /s3/SURVEY_ID) and direct numeric IDs.
- Updated `getContactId`, `addContactToCampaign`, and `sendInvitation` to utilize the new/updated extraction methods, ensuring correct survey and campaign IDs are used in Alchemer API calls. Logic includes defaulting campaign ID to survey ID in contexts where this is appropriate (e.g., default campaigns or if a specific campaign ID isn't found).