### PR TITLE
Make last contact fields read-only

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -357,8 +357,10 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 		phone = new TextField("Teléfono");
 		// dateOfBirth = new DatePicker("Fecha de Nacimiento"); // Removed
 		// occupation = new TextField("Ocupación"); // Removed
-		lastContacted = new DatePicker("Último Contacto");
-		lastInterviewed = new DatePicker("Última Encueesta");
+                lastContacted = new DatePicker("Último Contacto");
+                lastContacted.setReadOnly(true);
+                lastInterviewed = new DatePicker("Última Encueesta");
+                lastInterviewed.setReadOnly(true);
 		// START: Add properties field - Removed
 		// propertiesField = new MultiSelectListBox<>(); // Removed
 		// propertiesField.setItems(panelistPropertyService.findAll()); // Removed


### PR DESCRIPTION
## Summary
- ensure the `Último Contacto` and `Última Encueesta` date pickers in `PanelistsView` are read-only

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863dbc04f0c832a807f7eab15f8c1ff