### PR TITLE
Add SQL for MessageTask-Survey link

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/MessageTask.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/MessageTask.java
@@ -28,6 +28,11 @@ public class MessageTask extends AbstractEntity {
     @JoinColumn(name = "survey_panelist_participation_id")
     private SurveyPanelistParticipation surveyPanelistParticipation;
 
+    @ManyToOne
+    @JoinColumn(name = "survey_id")
+    @NotNull
+    private Survey survey;
+
     public JobType getJobType() {
         return jobType;
     }
@@ -58,5 +63,13 @@ public class MessageTask extends AbstractEntity {
 
     public void setSurveyPanelistParticipation(SurveyPanelistParticipation surveyPanelistParticipation) {
         this.surveyPanelistParticipation = surveyPanelistParticipation;
+    }
+
+    public Survey getSurvey() {
+        return survey;
+    }
+
+    public void setSurvey(Survey survey) {
+        this.survey = survey;
     }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -387,6 +387,7 @@ public class SurveysView extends Div implements BeforeEnterObserver {
                 mt.setCreated(LocalDateTime.now());
                 mt.setStatus(MessageTaskStatus.PENDING);
                 mt.setSurveyPanelistParticipation(participation); // Set the participation
+                mt.setSurvey(currentSurveyWithParticipations); // Associate survey
                 messageTaskService.save(mt);
                 tasksCreated++;
             }
@@ -424,6 +425,7 @@ public class SurveysView extends Div implements BeforeEnterObserver {
                 mt.setCreated(LocalDateTime.now());
                 mt.setStatus(MessageTaskStatus.PENDING); // Assuming PENDING exists
                 mt.setSurveyPanelistParticipation(participation); // Set the participation
+                mt.setSurvey(currentSurveyWithParticipations); // Associate survey
                 messageTaskService.save(mt);
                 tasksCreated++;
             }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -35,3 +35,6 @@ CREATE TABLE IF NOT EXISTS survey_panelist_participation (
     FOREIGN KEY (survey_id) REFERENCES survey(id),
     FOREIGN KEY (panelist_id) REFERENCES panelist(id)
 );
+-- Add survey_id column to message_task
+ALTER TABLE message_task ADD COLUMN survey_id BIGINT;
+ALTER TABLE message_task ADD CONSTRAINT fk_message_task_survey FOREIGN KEY (survey_id) REFERENCES survey(id);


### PR DESCRIPTION
## Summary
- include SQL snippet to add `survey_id` to `message_task`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `./mvnw -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863f293cc14832ab162207e866ee5b5