### PR TITLE
Fix: Correct navigation path for Usuarios view

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/MainLayout.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/MainLayout.java
@@ -73,14 +73,22 @@ public class MainLayout extends AppLayout {
     private SideNav createNavigation() {
         SideNav nav = new SideNav();
 
+        // Add other menu items, excluding "Usuarios"
         List<MenuEntry> menuEntries = MenuConfiguration.getMenuEntries();
-        menuEntries.forEach(entry -> {
-            if (entry.icon() != null) {
-                nav.addItem(new SideNavItem(entry.title(), entry.path(), new SvgIcon(entry.icon())));
-            } else {
-                nav.addItem(new SideNavItem(entry.title(), entry.path()));
-            }
-        });
+        menuEntries.stream()
+                .filter(entry -> !entry.title().equals("Usuarios"))
+                .forEach(entry -> {
+                    if (entry.icon() != null) {
+                        nav.addItem(new SideNavItem(entry.title(), entry.path(), new SvgIcon(entry.icon())));
+                    } else {
+                        nav.addItem(new SideNavItem(entry.title(), entry.path()));
+                    }
+                });
+
+        // Add "Configuración" with "Usuarios" as a sub-item
+        SideNavItem configuracionItem = new SideNavItem("Configuración");
+        configuracionItem.addItem(new SideNavItem("Usuarios", "users")); // Corrected path
+        nav.addItem(configuracionItem);
 
         return nav;
     }


### PR DESCRIPTION
The previous path "usuarios" was causing a NumberFormatException because it was being handled by PanelsView, which expects a numeric ID.

This commit updates the path to "users", which is the correct route for UsersView.