### PR TITLE
Fix: Correct parameter type in findAllByJobTypeAndStatus

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/services/MessageTaskService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/MessageTaskService.java
@@ -22,7 +22,7 @@ public class MessageTaskService {
         return repository.save(messageTask);
     }
 
-    public List<MessageTask> findAllByJobTypeAndStatus(JobType jobType, MessageTaskS tatus status) {
+    public List<MessageTask> findAllByJobTypeAndStatus(JobType jobType, MessageTaskStatus status) {
         return repository.findAllByJobTypeAndStatus(jobType, status);
     }
 


### PR DESCRIPTION
- Changed parameter type from MessageTask to MessageTaskStatus in MessageTaskService.
- This resolves compilation errors in AlchemerInviteSender and AlchemerReminderSender.