### PR TITLE
Fix: Correct method signature for findAllByJobTypeAndStatus

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/services/MessageTaskService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/MessageTaskService.java
@@ -22,7 +22,7 @@ public class MessageTaskService {
         return repository.save(messageTask);
     }
 
-    public List<MessageTask> findAllByJobTypeAndStatus(JobType jobType, MessageTaskS tatus status) {
+    public List<MessageTask> findAllByJobTypeAndStatus(JobType jobType, MessageTaskStatus status) {
         return repository.findAllByJobTypeAndStatus(jobType, status);
     }
 


### PR DESCRIPTION
Corrected a typo in MessageTaskService from `MessageTaskS tatus` to `MessageTaskStatus`. This ensures the method signature correctly aligns with MessageTaskRepository and the calling methods in AlchemerInviteSender and AlchemerReminderSender.