### PR TITLE
Fix: Resolve Specification compilation errors in PanelistsView

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
+import org.springframework.data.jpa.domain.Specification; // Added import for Specification
 
 import jakarta.annotation.security.PermitAll;
 import uy.com.equipos.panelmanagement.data.Panel;


### PR DESCRIPTION
- Added missing import for org.springframework.data.jpa.domain.Specification.
- This resolves the 'Specification cannot be resolved to a type' and the related 'The target type of this expression must be a functional interface' errors.