### PR TITLE
feat: Add alchemerSurveyId to Survey entity

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/Survey.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Survey.java
@@ -24,6 +24,8 @@ public class Survey extends AbstractEntity {
     @OneToMany(mappedBy = "survey")
     private Set<SurveyPanelistParticipation> participations = new HashSet<>();
 
+    private String alchemerSurveyId;
+
     public String getName() {
         return name;
     }
@@ -57,6 +59,14 @@ public class Survey extends AbstractEntity {
 
     public void setParticipations(Set<SurveyPanelistParticipation> participations) {
         this.participations = participations;
+    }
+
+    public String getAlchemerSurveyId() {
+        return alchemerSurveyId;
+    }
+
+    public void setAlchemerSurveyId(String alchemerSurveyId) {
+        this.alchemerSurveyId = alchemerSurveyId;
     }
 
     // The relationship from Survey to MessageTask is now indirect via SurveyPanelistParticipation.

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -217,6 +217,23 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 					this.survey = new Survey();
 				}
 				binder.writeBean(this.survey);
+
+				// Extract and set alchemerSurveyId from link
+				String surveyLink = this.survey.getLink();
+				if (surveyLink != null && !surveyLink.isEmpty()) {
+					// Example link: https://app.alchemer.com/invite/messages/id/8378285/link/24121332
+					// Regex to find .../id/THIS_PART/link/...
+					java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("/id/(\\d+)/link/");
+					java.util.regex.Matcher matcher = pattern.matcher(surveyLink);
+					if (matcher.find()) {
+						this.survey.setAlchemerSurveyId(matcher.group(1));
+					} else {
+						this.survey.setAlchemerSurveyId(null); // Or empty string, depending on desired behavior
+					}
+				} else {
+					this.survey.setAlchemerSurveyId(null); // Or empty string
+				}
+
 				surveyService.save(this.survey);
 				clearForm();
 				refreshGrid();


### PR DESCRIPTION
Added alchemerSurveyId field to the Survey entity. Implemented logic in SurveysView to parse this ID from the 'link' field when a survey is saved, if the link matches the Alchemer pattern. The ID is extracted from URLs like:
https://app.alchemer.com/invite/messages/id/EXTRACTED_ID/link/OTHER_ID