### PR TITLE
Apply dd/MM/yyyy date format to DatePickers

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/MessageTaskView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/MessageTaskView.java
@@ -3,10 +3,12 @@ package uy.com.equipos.panelmanagement.views;
 import java.time.LocalDate; // Added for LocalDate comparison
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.HashMap; // Added for filter map
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Locale;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -95,7 +97,21 @@ public class MessageTaskView extends Div implements HasComponents, HasStyle {
     private DatePicker createDatePickerFilter(String filterKey) {
         DatePicker datePicker = new DatePicker();
         datePicker.setWidthFull();
-        datePicker.setPlaceholder("Filter by date");
+        // Apply Spanish locale for dd/MM/yyyy format
+        // Create a custom I18n object for DatePicker
+        DatePicker.DatePickerI18n dpI18n = new DatePicker.DatePickerI18n();
+        dpI18n.setDateFormat("dd/MM/yyyy");
+        // You can customize other i18n properties here if needed
+        // For example, month names, weekdays, etc.
+        // dpI18n.setMonthNames(List.of("Enero", "Febrero", ..., "Diciembre"));
+        // dpI18n.setWeekdays(List.of("Domingo", "Lunes", ..., "Sábado"));
+        // dpI18n.setToday("Hoy");
+        // dpI18n.setCancel("Cancelar");
+        // dpI18n.setFirstDayOfWeek(1); // Monday
+
+        datePicker.setI18n(dpI18n);
+        datePicker.setLocale(new Locale("es", "UY")); // Spanish, Uruguay for dd/MM/yyyy
+        datePicker.setPlaceholder("dd/MM/yyyy");
         datePicker.setClearButtonVisible(true);
         datePicker.addValueChangeListener(event -> {
             LocalDate selectedDate = event.getValue();

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap; // Added
 import java.util.HashSet;
 import java.util.List; // Make sure this is present
+import java.util.Locale;
 import java.util.Map; // Added
 import java.util.Optional;
 import java.util.Set;
@@ -237,8 +238,18 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 		// dateOfBirthFilter.setPlaceholder("Filtrar por Fecha de Nacimiento"); //
 		// Removed
 		// occupationFilter.setPlaceholder("Filtrar por Ocupación"); // Removed
-		lastContactedFilter.setPlaceholder("Filtrar por Último Contacto");
-		lastInterviewCompletedFilter.setPlaceholder("Filtrar por Última Encuesta");
+		lastContactedFilter.setPlaceholder("dd/MM/yyyy");
+		lastContactedFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n lastContactedI18n = new DatePicker.DatePickerI18n();
+		lastContactedI18n.setDateFormat("dd/MM/yyyy");
+		lastContactedFilter.setI18n(lastContactedI18n);
+
+		lastInterviewCompletedFilter.setPlaceholder("dd/MM/yyyy");
+		lastInterviewCompletedFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n lastInterviewCompletedI18n = new DatePicker.DatePickerI18n();
+		lastInterviewCompletedI18n.setDateFormat("dd/MM/yyyy");
+		lastInterviewCompletedFilter.setI18n(lastInterviewCompletedI18n);
+
 		sourceFilter.setPlaceholder("Filtrar por Fuente"); // Added placeholder for source filter
 
 		// Añadir listeners para refrescar el grid
@@ -409,8 +420,17 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 		// occupation = new TextField("Ocupación"); // Removed
 		lastContacted = new DatePicker("Último encuesta enviada");
 		lastContacted.setReadOnly(true);
+		lastContacted.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n lcI18n = new DatePicker.DatePickerI18n();
+		lcI18n.setDateFormat("dd/MM/yyyy");
+		lastContacted.setI18n(lcI18n);
+
 		lastInterviewCompleted = new DatePicker("Última encuesta completa");
 		lastInterviewCompleted.setReadOnly(true);
+		lastInterviewCompleted.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n licI18n = new DatePicker.DatePickerI18n();
+		licI18n.setDateFormat("dd/MM/yyyy");
+		lastInterviewCompleted.setI18n(licI18n);
 
 		// START: Add properties field - Removed
 		// propertiesField = new MultiSelectListBox<>(); // Removed
@@ -562,11 +582,19 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 		filterRow.getCell(surveyNameCol).setComponent(surveyNameFilter);
 
 		DatePicker dateSentFilter = new DatePicker();
-		dateSentFilter.setPlaceholder("Filtrar...");
+		dateSentFilter.setPlaceholder("dd/MM/yyyy");
+		dateSentFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n dsfI18n = new DatePicker.DatePickerI18n();
+		dsfI18n.setDateFormat("dd/MM/yyyy");
+		dateSentFilter.setI18n(dsfI18n);
 		filterRow.getCell(dateSentCol).setComponent(dateSentFilter);
 
 		DatePicker dateCompletedFilter = new DatePicker();
-		dateCompletedFilter.setPlaceholder("Filtrar...");
+		dateCompletedFilter.setPlaceholder("dd/MM/yyyy");
+		dateCompletedFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n dcfI18n = new DatePicker.DatePickerI18n();
+		dcfI18n.setDateFormat("dd/MM/yyyy");
+		dateCompletedFilter.setI18n(dcfI18n);
 		filterRow.getCell(dateCompletedCol).setComponent(dateCompletedFilter);
 
 		ComboBox<String> completedFilter = new ComboBox<>();
@@ -890,13 +918,24 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 			switch (type) {
 			case FECHA:
 				DatePicker datePicker = new DatePicker();
-				datePicker.setPlaceholder("Seleccione fecha...");
+				datePicker.setPlaceholder("dd/MM/yyyy");
+				datePicker.setLocale(new Locale("es", "UY"));
+				DatePicker.DatePickerI18n dpI18n = new DatePicker.DatePickerI18n();
+				dpI18n.setDateFormat("dd/MM/yyyy");
+				datePicker.setI18n(dpI18n);
 				if (existingValue != null && !existingValue.isEmpty()) {
 					try {
+						// Attempt to parse if it's in ISO format (yyyy-MM-dd) first
 						datePicker.setValue(LocalDate.parse(existingValue));
 					} catch (DateTimeParseException e) {
-						// Handle or log parsing error, maybe set to null
-						datePicker.setValue(null);
+						// If ISO parsing fails, try dd/MM/yyyy (though data should ideally be stored in ISO)
+						try {
+							DateTimeFormatter customFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+							datePicker.setValue(LocalDate.parse(existingValue, customFormatter));
+						} catch (DateTimeParseException ex) {
+							// Handle or log parsing error, maybe set to null
+							datePicker.setValue(null);
+						}
 					}
 				}
 				editorComponent = datePicker;

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelistPropertyFilterDialog.java
@@ -2,6 +2,7 @@ package uy.com.equipos.panelmanagement.views.panels;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import com.vaadin.flow.component.Component;
@@ -179,8 +180,13 @@ public class PanelistPropertyFilterDialog extends Dialog {
                 ((TextField) editorComponent).setPlaceholder("Valor de texto...");
                 break;
             case FECHA:
-                editorComponent = new DatePicker();
-                ((DatePicker) editorComponent).setPlaceholder("Seleccione fecha...");
+                DatePicker datePicker = new DatePicker();
+                datePicker.setPlaceholder("dd/MM/yyyy");
+                datePicker.setLocale(new Locale("es", "UY"));
+                DatePicker.DatePickerI18n dpI18n = new DatePicker.DatePickerI18n();
+                dpI18n.setDateFormat("dd/MM/yyyy");
+                datePicker.setI18n(dpI18n);
+                editorComponent = datePicker;
                 break;
             case NUMERO:
                 // Usar TextField para números, se puede añadir validación o máscara si es necesario.

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
@@ -1,6 +1,7 @@
 package uy.com.equipos.panelmanagement.views.panels;
 
 import java.time.LocalDate;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -190,7 +191,13 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 		// Configurar placeholders para filtros (ya deberían estar inicializados como
 		// miembros de clase)
 		nameFilter.setPlaceholder("Filtrar por Nombre");
-		createdFilter.setPlaceholder("Filtrar por Fecha de Creación");
+
+		createdFilter.setPlaceholder("dd/MM/yyyy");
+		createdFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n cfI18n = new DatePicker.DatePickerI18n();
+		cfI18n.setDateFormat("dd/MM/yyyy");
+		createdFilter.setI18n(cfI18n);
+
 		activeFilter.setPlaceholder("Filtrar por Estado");
 		activeFilter.setItems("Todos", "Activo", "Inactivo"); // Estos ya están en español o son universales
 		activeFilter.setValue("Todos");
@@ -299,6 +306,10 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 		FormLayout formLayout = new FormLayout();
 		name = new TextField("Nombre");
 		created = new DatePicker("Fecha de Creación");
+		created.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n cI18n = new DatePicker.DatePickerI18n();
+		cI18n.setDateFormat("dd/MM/yyyy");
+		created.setI18n(cI18n);
 		active = new Checkbox("Activo");
 		formLayout.add(name, created, active, addPanelistsButton, viewPanelistsButton);
 

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -164,7 +165,13 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 
 		// Configurar placeholders para filtros
 		nameFilter.setPlaceholder("Filtrar por Nombre");
-		initDateFilter.setPlaceholder("Filtrar por Fecha de Inicio");
+
+		initDateFilter.setPlaceholder("dd/MM/yyyy");
+		initDateFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n idfI18n = new DatePicker.DatePickerI18n();
+		idfI18n.setDateFormat("dd/MM/yyyy");
+		initDateFilter.setI18n(idfI18n);
+
 		linkFilter.setPlaceholder("Filtrar por Enlace");
 		toolFilter.setPlaceholder("Filtrar por Herramienta");
 		toolFilter.setItems(Tool.values());
@@ -291,6 +298,11 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 		FormLayout formLayout = new FormLayout();
 		name = new TextField("Nombre");
 		initDate = new DatePicker("Fecha de Inicio");
+		initDate.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n idI18n = new DatePicker.DatePickerI18n();
+		idI18n.setDateFormat("dd/MM/yyyy");
+		initDate.setI18n(idI18n);
+
 		link = new TextField("Enlace");
 		tool = new ComboBox<>("Herramienta");
 		tool.setItems(Tool.values());
@@ -629,17 +641,29 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 		filterRow.getCell(participationsGrid.getColumnByKey("panelistEmail")).setComponent(panelistEmailFilter);
 
 		DatePicker dateIncludedFilter = new DatePicker();
-		dateIncludedFilter.setPlaceholder("Filtrar Fecha");
+		dateIncludedFilter.setPlaceholder("dd/MM/yyyy");
+		dateIncludedFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n difI18n = new DatePicker.DatePickerI18n();
+		difI18n.setDateFormat("dd/MM/yyyy");
+		dateIncludedFilter.setI18n(difI18n);
 		dateIncludedFilter.setClearButtonVisible(true);
 		filterRow.getCell(dateIncludedColumn).setComponent(dateIncludedFilter);
 
 		DatePicker dateSentFilter = new DatePicker();
-		dateSentFilter.setPlaceholder("Filtrar Fecha");
+		dateSentFilter.setPlaceholder("dd/MM/yyyy");
+		dateSentFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n dsfI18n = new DatePicker.DatePickerI18n();
+		dsfI18n.setDateFormat("dd/MM/yyyy");
+		dateSentFilter.setI18n(dsfI18n);
 		dateSentFilter.setClearButtonVisible(true);
 		filterRow.getCell(dateSentColumn).setComponent(dateSentFilter);
 
 		DatePicker dateCompletedFilter = new DatePicker();
-		dateCompletedFilter.setPlaceholder("Filtrar Fecha");
+		dateCompletedFilter.setPlaceholder("dd/MM/yyyy");
+		dateCompletedFilter.setLocale(new Locale("es", "UY"));
+		DatePicker.DatePickerI18n dcfI18n = new DatePicker.DatePickerI18n();
+		dcfI18n.setDateFormat("dd/MM/yyyy");
+		dateCompletedFilter.setI18n(dcfI18n);
 		dateCompletedFilter.setClearButtonVisible(true);
 		filterRow.getCell(dateCompletedColumn).setComponent(dateCompletedFilter);
 


### PR DESCRIPTION
Updated DatePicker instances across various views to use the dd/MM/yyyy format by setting the locale to es-UY and configuring DatePickerI18n with the specified date format string.

Files modified:
- MessageTaskView.java
- PanelistsView.java
- PanelistPropertyFilterDialog.java
- PanelsView.java
- SurveysView.java