### PR TITLE
Agregar control de email duplicado al crear panelista

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistRepository.java
@@ -15,4 +15,6 @@ public interface PanelistRepository extends JpaRepository<Panelist, Long>, JpaSp
     // Optional<Panelist> findByIdWithParticipations(@Param("id") Long id);
 
     Optional<Panelist> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistService.java
@@ -54,6 +54,11 @@ public class PanelistService {
         return get(id);
     }
 
+    @Transactional(readOnly = true)
+    public boolean existsByEmail(String email) {
+        return repository.existsByEmail(email);
+    }
+
     public Panelist save(Panelist entity) {
         return repository.save(entity);
     }

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -354,7 +354,18 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 				if (this.panelist == null) {
 					this.panelist = new Panelist();
 				}
+
+				// Primero intentar escribir los datos del binder para asegurar que el email está disponible
 				binder.writeBean(this.panelist);
+
+				// Verificar si es un nuevo panelista y si el correo electrónico ya existe
+				if (this.panelist.getId() == null && this.panelist.getEmail() != null && !this.panelist.getEmail().isEmpty()) {
+					if (panelistService.existsByEmail(this.panelist.getEmail())) {
+						Notification.show("Ya existe un panelista con el correo electrónico: " + this.panelist.getEmail(), 5000, Notification.Position.MIDDLE)
+								.addThemeVariants(NotificationVariant.LUMO_ERROR);
+						return; // Detener el proceso de guardado
+					}
+				}
 
 				// Set<PanelistProperty> selectedProperties = propertiesField.getValue(); //
 				// Removed


### PR DESCRIPTION
Se implementó una validación para prevenir la creación de panelistas con un correo electrónico que ya existe en la base de datos.

Cambios realizados:
- Se agregó el método `existsByEmail(String email)` a `PanelistService` y `PanelistRepository`.
- Se modificó `PanelistsView` para utilizar este nuevo método en el proceso de guardado de un nuevo panelista, mostrando un error si el email ya está en uso.