### PR TITLE
feat: Add Answer entity, AnswersView, and navigation link

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/Answer.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/Answer.java
@@ -1,0 +1,55 @@
+package uy.com.equipos.panelmanagement.data;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+
+@Entity
+@Table(name = "answers")
+public class Answer extends AbstractEntity {
+
+    private String question;
+    private String questionCode;
+    private String answer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_panelist_participation_id")
+    private SurveyPanelistParticipation surveyPanelistParticipation;
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(String question) {
+        this.question = question;
+    }
+
+    public String getQuestionCode() {
+        return questionCode;
+    }
+
+    public void setQuestionCode(String questionCode) {
+        this.questionCode = questionCode;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    public SurveyPanelistParticipation getSurveyPanelistParticipation() {
+        return surveyPanelistParticipation;
+    }
+
+    public void setSurveyPanelistParticipation(SurveyPanelistParticipation surveyPanelistParticipation) {
+        this.surveyPanelistParticipation = surveyPanelistParticipation;
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/AnswerRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/AnswerRepository.java
@@ -1,0 +1,7 @@
+package uy.com.equipos.panelmanagement.data;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long>, JpaSpecificationExecutor<Answer> {
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/data/SurveyPanelistParticipation.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/SurveyPanelistParticipation.java
@@ -80,11 +80,22 @@ public class SurveyPanelistParticipation extends AbstractEntity {
     @OneToMany(mappedBy = "surveyPanelistParticipation", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Task> messageTasks = new HashSet<>();
 
+    @OneToMany(mappedBy = "surveyPanelistParticipation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Answer> answers = new HashSet<>();
+
     public Set<Task> getMessageTasks() {
         return messageTasks;
     }
 
     public void setMessageTasks(Set<Task> messageTasks) {
         this.messageTasks = messageTasks;
+    }
+
+    public Set<Answer> getAnswers() {
+        return answers;
+    }
+
+    public void setAnswers(Set<Answer> answers) {
+        this.answers = answers;
     }
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/AnswerService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/AnswerService.java
@@ -1,0 +1,36 @@
+package uy.com.equipos.panelmanagement.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uy.com.equipos.panelmanagement.data.Answer;
+import uy.com.equipos.panelmanagement.data.AnswerRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class AnswerService {
+
+    private final AnswerRepository answerRepository;
+
+    @Autowired
+    public AnswerService(AnswerRepository answerRepository) {
+        this.answerRepository = answerRepository;
+    }
+
+    public List<Answer> findAll() {
+        return answerRepository.findAll();
+    }
+
+    public Optional<Answer> findById(Long id) {
+        return answerRepository.findById(id);
+    }
+
+    public Answer save(Answer answer) {
+        return answerRepository.save(answer);
+    }
+
+    public void deleteById(Long id) {
+        answerRepository.deleteById(id);
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/views/AnswersView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/AnswersView.java
@@ -1,0 +1,116 @@
+package uy.com.equipos.panelmanagement.views;
+
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.grid.dataview.GridListDataView;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.function.SerializablePredicate;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.RolesAllowed;
+import org.springframework.beans.factory.annotation.Autowired;
+import uy.com.equipos.panelmanagement.data.Answer;
+import uy.com.equipos.panelmanagement.services.AnswerService; // Asumiendo que existirá un AnswerService
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@PageTitle("Respuestas")
+@Route(value = "answers", layout = MainLayout.class)
+@RolesAllowed("ADMIN") // O el rol que corresponda
+public class AnswersView extends Div implements HasComponents, HasStyle {
+
+    private Grid<Answer> grid = new Grid<>(Answer.class, false);
+    private GridListDataView<Answer> gridListDataView;
+    private final Map<String, SerializablePredicate<Answer>> activeFilters = new HashMap<>();
+
+    private final AnswerService answerService;
+
+    @Autowired
+    public AnswersView(AnswerService answerService) {
+        this.answerService = answerService;
+        addClassNames("answers-view");
+        setSizeFull();
+        configureGrid();
+        loadGridData();
+        add(grid);
+    }
+
+    private void configureGrid() {
+        grid.addColumn(Answer::getId).setHeader("Id").setAutoWidth(true).setSortable(true).setKey("id");
+        grid.addColumn(Answer::getQuestion).setHeader("Pregunta").setAutoWidth(true).setSortable(true).setKey("question");
+        grid.addColumn(Answer::getQuestionCode).setHeader("Código Pregunta").setAutoWidth(true).setSortable(true).setKey("questionCode");
+        grid.addColumn(Answer::getAnswer).setHeader("Respuesta").setAutoWidth(true).setSortable(true).setKey("answer");
+        grid.addColumn(answer -> answer.getSurveyPanelistParticipation() != null && answer.getSurveyPanelistParticipation().getPanelist() != null ?
+                        answer.getSurveyPanelistParticipation().getPanelist().getFullName() : null)
+                .setHeader("Panelista").setAutoWidth(true).setSortable(true).setKey("panelist");
+
+        HeaderRow filterRow = grid.appendHeaderRow();
+
+        TextField idFilter = createTextFieldFilter("id_filter", Answer::getId);
+        filterRow.getCell(grid.getColumnByKey("id")).setComponent(idFilter);
+
+        TextField questionFilter = createTextFieldFilter("question_filter", Answer::getQuestion);
+        filterRow.getCell(grid.getColumnByKey("question")).setComponent(questionFilter);
+
+        TextField questionCodeFilter = createTextFieldFilter("questionCode_filter", Answer::getQuestionCode);
+        filterRow.getCell(grid.getColumnByKey("questionCode")).setComponent(questionCodeFilter);
+
+        TextField answerFilter = createTextFieldFilter("answer_filter", Answer::getAnswer);
+        filterRow.getCell(grid.getColumnByKey("answer")).setComponent(answerFilter);
+
+        TextField panelistFilter = createTextFieldFilter("panelist_filter", answer ->
+            answer.getSurveyPanelistParticipation() != null && answer.getSurveyPanelistParticipation().getPanelist() != null ?
+            answer.getSurveyPanelistParticipation().getPanelist().getFullName() : "");
+        filterRow.getCell(grid.getColumnByKey("panelist")).setComponent(panelistFilter);
+
+        grid.setSizeFull();
+    }
+
+    private TextField createTextFieldFilter(String filterKey, ValueProvider<Answer, ?> valueProvider) {
+        TextField filterField = new TextField();
+        filterField.setWidthFull();
+        filterField.setPlaceholder("Filtrar...");
+        filterField.setClearButtonVisible(true);
+        filterField.setValueChangeMode(ValueChangeMode.LAZY);
+        filterField.addValueChangeListener(event -> {
+            String filterValue = event.getValue() != null ? event.getValue().toLowerCase() : "";
+            if (filterValue.isEmpty()) {
+                activeFilters.remove(filterKey);
+            } else {
+                activeFilters.put(filterKey, (SerializablePredicate<Answer>) answer ->
+                        Objects.toString(valueProvider.apply(answer), "").toLowerCase().contains(filterValue)
+                );
+            }
+            applyFilters();
+        });
+        return filterField;
+    }
+
+    private void applyFilters() {
+        if (gridListDataView == null) {
+            return;
+        }
+        SerializablePredicate<Answer> combinedFilter = activeFilters.values().stream()
+                .reduce(SerializablePredicate::and)
+                .orElse(task -> true);
+        gridListDataView.setFilter(combinedFilter);
+    }
+
+    @FunctionalInterface
+    interface ValueProvider<T, R> {
+        R apply(T t);
+    }
+
+    private void loadGridData() {
+        List<Answer> answers = answerService.findAll(); // Asumiendo que AnswerService tiene un método findAll()
+        gridListDataView = grid.setItems(answers);
+        applyFilters();
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/views/MainLayout.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/MainLayout.java
@@ -83,6 +83,11 @@ public class MainLayout extends AppLayout {
 			}
 		});
 
+		// Add "Respuestas"
+		SideNavItem answersItem = new SideNavItem("Respuestas", "answers");
+		answersItem.setPrefixComponent(new Icon("vaadin", "comments-o"));
+		nav.addItem(answersItem);
+
 		// Add "Configuración" with "Usuarios" and "Tareas" as sub-items
 		SideNavItem configuracionItem = new SideNavItem("Configuración");
 		configuracionItem.setPrefixComponent(new Icon("vaadin", "tools"));


### PR DESCRIPTION
- Created Answer entity with question, questionCode, answer attributes and N:1 relationship with SurveyPanelistParticipation.
- Added OneToMany relationship from SurveyPanelistParticipation to Answer.
- Created AnswersView similar to TasksView to display Answer entities in a grid.
- Implemented AnswerRepository and AnswerService for data handling.
- Added a link to AnswersView in the side navigation with the title 'Respuestas' and icon 'vaadin:comments-o'.