### PR TITLE
Refactor: Keep forms open and buttons enabled after save

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -373,10 +373,12 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 				// will be handled by PanelistPropertyValue logic later
 
 				panelistService.save(this.panelist);
-				clearForm();
-				refreshGrid();
-				Notification.show("Datos actualizados");
-				UI.getCurrent().navigate(PanelistsView.class);
+				Notification.show("Datos guardados");
+				// clearForm(); // Keep form open
+				// refreshGrid(); // Keep form data, refresh grid in background if necessary or let user do it manually
+				grid.getDataProvider().refreshItem(this.panelist, true); // Refresh only the updated/created item in the grid
+                                populateForm(this.panelist); // Re-populate to ensure button states are correct
+				// UI.getCurrent().navigate(PanelistsView.class); // Keep user on the edit view
 			} catch (ObjectOptimisticLockingFailureException exception) {
 				Notification n = Notification.show(
 						"Error al actualizar los datos. Otro usuario modificó el registro mientras usted realizaba cambios.");

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panels/PanelsView.java
@@ -255,10 +255,12 @@ public class PanelsView extends Div implements BeforeEnterObserver {
 				}
 				binder.writeBean(this.panel);
 				panelService.save(this.panel);
-				clearForm();
-				refreshGrid();
-				Notification.show("Datos actualizados");
-				UI.getCurrent().navigate(PanelsView.class);
+				Notification.show("Datos guardados");
+				// clearForm(); // Keep form open
+				// refreshGrid(); // Keep form data, refresh grid in background if necessary or let user do it manually
+				grid.getDataProvider().refreshItem(this.panel, true); // Refresh only the updated/created item in the grid
+                                populateForm(this.panel); // Re-populate to ensure button states are correct
+				// UI.getCurrent().navigate(PanelsView.class); // Keep user on the edit view
 			} catch (ObjectOptimisticLockingFailureException exception) {
 				Notification n = Notification.show(
 						"Error al actualizar los datos. Otro usuario modificó el registro mientras usted realizaba cambios.");

--- a/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/surveys/SurveysView.java
@@ -243,11 +243,13 @@ public class SurveysView extends Div implements BeforeEnterObserver {
 				}
 
 				surveyService.save(this.survey);
-				
-				Notification.show("Datos actualizados");
-				clearForm();
-				refreshGrid();
-				UI.getCurrent().navigate(SurveysView.class);
+
+				Notification.show("Datos guardados");
+				// clearForm(); // Keep form open
+				// refreshGrid(); // Keep form data, refresh grid in background if necessary or let user do it manually
+				grid.getDataProvider().refreshItem(this.survey, true); // Refresh only the updated/created item in the grid
+                                populateForm(this.survey); // Re-populate to ensure button states are correct
+				// UI.getCurrent().navigate(SurveysView.class); // Keep user on the edit view
 			} catch (ObjectOptimisticLockingFailureException exception) {
 				Notification n = Notification.show(
 						"Error al actualizar los datos. Otro usuario modificó el registro mientras usted realizaba cambios.");


### PR DESCRIPTION
Modified SurveysView, PanelistsView, and PanelsView so that when the 'Guardar' (Save) button is clicked:
- The form remains open with the current data.
- A notification 'Datos guardados' is shown.
- The relevant buttons in the form remain enabled.
- The grid is updated to reflect the saved item without a full refresh or navigation.

This change improves user experience by allowing further edits or actions without needing to re-select the item or navigate away from the form.