### PR TITLE
Feat: Update existing answers instead of creating duplicates

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/AnswerRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/AnswerRepository.java
@@ -2,6 +2,11 @@ package uy.com.equipos.panelmanagement.data;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import uy.com.equipos.panelmanagement.data.SurveyPanelistParticipation; // Added import
+
+import java.util.Optional; // Added import
 
 public interface AnswerRepository extends JpaRepository<Answer, Long>, JpaSpecificationExecutor<Answer> {
+
+    Optional<Answer> findBySurveyPanelistParticipationAndQuestionCode(SurveyPanelistParticipation surveyPanelistParticipation, String questionCode);
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/AnswerService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/AnswerService.java
@@ -33,4 +33,9 @@ public class AnswerService {
     public void deleteById(Long id) {
         answerRepository.deleteById(id);
     }
+
+    public Optional<Answer> findBySurveyPanelistParticipationAndQuestionCode(
+            uy.com.equipos.panelmanagement.data.SurveyPanelistParticipation participation, String questionCode) {
+        return answerRepository.findBySurveyPanelistParticipationAndQuestionCode(participation, questionCode);
+    }
 }


### PR DESCRIPTION
Modified AlchemerAnswerRetriever to check if an answer already exists for a given SurveyPanelistParticipation and questionCode.

- If an answer exists, its 'answer' field is updated with the new value from Alchemer.
- If no answer exists, a new Answer entity is created.

This prevents the creation of duplicate Answer records for the same question and participation, ensuring data integrity.

Changes include:
- Updated logic in `AlchemerAnswerRetriever`.
- Added `findBySurveyPanelistParticipationAndQuestionCode` method to `AnswerRepository` and `AnswerService` to support this check.