### PR TITLE
Fix LazyInitializationException in AnswersView

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/data/AnswerRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/AnswerRepository.java
@@ -1,12 +1,17 @@
 package uy.com.equipos.panelmanagement.data;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import uy.com.equipos.panelmanagement.data.SurveyPanelistParticipation; // Added import
 
+import java.util.List;
 import java.util.Optional; // Added import
 
 public interface AnswerRepository extends JpaRepository<Answer, Long>, JpaSpecificationExecutor<Answer> {
 
     Optional<Answer> findBySurveyPanelistParticipationAndQuestionCode(SurveyPanelistParticipation surveyPanelistParticipation, String questionCode);
+
+    @EntityGraph(attributePaths = { "surveyPanelistParticipation.panelist" })
+    List<Answer> findAll();
 }


### PR DESCRIPTION
Resolved an org.hibernate.LazyInitializationException that occurred when accessing the Panelist's full name in the AnswersView. The exception was caused by attempting to load the lazily-initialized `panelist` association outside of an active Hibernate session.

The fix involves using `@EntityGraph(attributePaths = { "surveyPanelistParticipation.panelist" })` on the `AnswerRepository.findAll()` method. This ensures that the `SurveyPanelistParticipation` and its associated `Panelist` are eagerly fetched within the same transaction, making the panelist's details available when the Vaadin Grid renders the data.