### PR TITLE
feat: Add webhook for form responses

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/webhook/WebhookController.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/webhook/WebhookController.java
@@ -1,0 +1,68 @@
+package uy.com.equipos.panelmanagement.webhook;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import uy.com.equipos.panelmanagement.data.JobType;
+import uy.com.equipos.panelmanagement.data.Panelist;
+import uy.com.equipos.panelmanagement.data.PanelistRepository;
+import uy.com.equipos.panelmanagement.data.Status;
+import uy.com.equipos.panelmanagement.data.Task;
+import uy.com.equipos.panelmanagement.data.TaskRepository;
+import uy.com.equipos.panelmanagement.data.TaskStatus;
+import uy.com.equipos.panelmanagement.webhook.dto.FormResponsePayload;
+
+@RestController
+@RequestMapping("/api/webhook")
+public class WebhookController {
+
+    private final PanelistRepository panelistRepository;
+    private final TaskRepository taskRepository;
+
+    public WebhookController(PanelistRepository panelistRepository, TaskRepository taskRepository) {
+        this.panelistRepository = panelistRepository;
+        this.taskRepository = taskRepository;
+    }
+
+    @PostMapping("/form-response")
+    public ResponseEntity<Void> handleFormResponse(@RequestBody FormResponsePayload payload) {
+        Map<String, String> fields = payload.getData().getFields().stream()
+            .collect(Collectors.toMap(FormResponsePayload.Field::getLabel, FormResponsePayload.Field::getValue));
+
+        String email = fields.get("Correo electrónico");
+        if (email == null || email.isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        Optional<Panelist> existingPanelist = panelistRepository.findByEmail(email);
+
+        if (existingPanelist.isEmpty()) {
+            Panelist newPanelist = new Panelist();
+            newPanelist.setFirstName(fields.get("Nombre"));
+            newPanelist.setLastName(fields.get("Apellido"));
+            newPanelist.setEmail(email);
+            newPanelist.setStatus(Status.PENDIENTE);
+            panelistRepository.save(newPanelist);
+
+            Task task = new Task();
+            task.setJobType(JobType.SCREENING);
+            task.setStatus(TaskStatus.PENDING);
+            task.setCreated(LocalDateTime.now());
+            task.setPanelist(newPanelist);
+            taskRepository.save(task);
+
+            return ResponseEntity.status(HttpStatus.CREATED).build();
+        } else {
+            return ResponseEntity.ok().build();
+        }
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/webhook/dto/FormResponsePayload.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/webhook/dto/FormResponsePayload.java
@@ -1,0 +1,184 @@
+package uy.com.equipos.panelmanagement.webhook.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class FormResponsePayload {
+
+    @JsonProperty("eventId")
+    private String eventId;
+
+    @JsonProperty("eventType")
+    private String eventType;
+
+    @JsonProperty("createdAt")
+    private String createdAt;
+
+    @JsonProperty("data")
+    private Data data;
+
+    // Getters and setters
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Data getData() {
+        return data;
+    }
+
+    public void setData(Data data) {
+        this.data = data;
+    }
+
+    public static class Data {
+
+        @JsonProperty("responseId")
+        private String responseId;
+
+        @JsonProperty("submissionId")
+        private String submissionId;
+
+        @JsonProperty("respondentId")
+        private String respondentId;
+
+        @JsonProperty("formId")
+        private String formId;
+
+        @JsonProperty("formName")
+        private String formName;
+
+        @JsonProperty("createdAt")
+        private String createdAt;
+
+        @JsonProperty("fields")
+        private List<Field> fields;
+
+        // Getters and setters
+
+        public String getResponseId() {
+            return responseId;
+        }
+
+        public void setResponseId(String responseId) {
+            this.responseId = responseId;
+        }
+
+        public String getSubmissionId() {
+            return submissionId;
+        }
+
+        public void setSubmissionId(String submissionId) {
+            this.submissionId = submissionId;
+        }
+
+        public String getRespondentId() {
+            return respondentId;
+        }
+
+        public void setRespondentId(String respondentId) {
+            this.respondentId = respondentId;
+        }
+
+        public String getFormId() {
+            return formId;
+        }
+
+        public void setFormId(String formId) {
+            this.formId = formId;
+        }
+
+        public String getFormName() {
+            return formName;
+        }
+
+        public void setFormName(String formName) {
+            this.formName = formName;
+        }
+
+        public String getCreatedAt() {
+            return createdAt;
+        }
+
+        public void setCreatedAt(String createdAt) {
+            this.createdAt = createdAt;
+        }
+
+        public List<Field> getFields() {
+            return fields;
+        }
+
+        public void setFields(List<Field> fields) {
+            this.fields = fields;
+        }
+    }
+
+    public static class Field {
+
+        @JsonProperty("key")
+        private String key;
+
+        @JsonProperty("label")
+        private String label;
+
+        @JsonProperty("type")
+        private String type;
+
+        @JsonProperty("value")
+        private String value;
+
+        // Getters and setters
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new webhook endpoint to handle form responses.

The endpoint `/api/webhook/form-response` receives a POST request with form data. It extracts the user's first name, last name, and email.

If a panelist with the given email does not exist, a new panelist is created with 'PENDIENTE' status, and a 'SCREENING' task is created for them.

If the panelist already exists, the endpoint returns a 200 OK response.