### PR TITLE
feat: Enhance RecruitmentView with new configuration fields

### DIFF
--- a/src/main/java/uy/com/equipos/panelmanagement/views/RecruitmentView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/RecruitmentView.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
@@ -21,40 +22,89 @@ public class RecruitmentView extends Div {
 
     private final ConfigurationItemService configurationItemService;
 
-    private static final String RECRUITMENT_MESSAGE_NAME = "recruitment.message.mail";
+    private static final String RECRUITMENT_INTRODUCTION_NAME = "recruitment.introduction";
+    private static final String RECRUITMENT_LANDING_URL_NAME = "recruitment.landing.url";
+    private static final String RECRUITMENT_ALCHEMER_STUDY_ID_NAME = "recruitment.alchemer.study.id";
+    private static final String RECRUITMENT_RETRY_NAME = "recruitment.retry";
 
-    private TextArea messageArea;
+    private TextArea introductionArea;
+    private TextField landingUrlField;
+    private TextField alchemerStudyIdField;
+    private TextField retryField;
     private Button saveButton;
 
     public RecruitmentView(ConfigurationItemService configurationItemService) {
         this.configurationItemService = configurationItemService;
-        addClassName("recruitment-message-view");
+        addClassName("recruitment-view");
 
-        messageArea = new TextArea();
-        messageArea.setWidthFull();
-        messageArea.setHeight("400px"); // Adjust height as needed
+        introductionArea = new TextArea("Introducción");
+        introductionArea.setWidthFull();
+        introductionArea.setReadOnly(true);
+
+        landingUrlField = new TextField("Url del Landing Page:");
+        landingUrlField.setWidthFull();
+
+        alchemerStudyIdField = new TextField("Id de estudio de Alchemer");
+        alchemerStudyIdField.setWidthFull();
+        alchemerStudyIdField.setPattern("[0-9]*");
+
+        retryField = new TextField("Cantidad de reintentos de envío del consentimiento");
+        retryField.setWidthFull();
+        retryField.setPattern("[0-9]*");
 
         saveButton = new Button("Guardar");
-        saveButton.addClickListener(e -> saveRecruitmentMessage());
+        saveButton.addClickListener(e -> saveConfiguration());
 
-        VerticalLayout layout = new VerticalLayout(messageArea, saveButton);
+        VerticalLayout layout = new VerticalLayout(introductionArea, landingUrlField, alchemerStudyIdField, retryField, saveButton);
         layout.setSizeFull();
         add(layout);
 
-        loadRecruitmentMessage();
+        loadConfiguration();
     }
 
-    private void loadRecruitmentMessage() {
-        Optional<ConfigurationItem> recruitmentMessage = configurationItemService.getByName(RECRUITMENT_MESSAGE_NAME);
-        recruitmentMessage.ifPresent(item -> messageArea.setValue(item.getValue()));
+    private void loadConfiguration() {
+        Optional<ConfigurationItem> introduction = configurationItemService.getByName(RECRUITMENT_INTRODUCTION_NAME);
+        introduction.ifPresent(item -> introductionArea.setValue(item.getValue()));
+
+        Optional<ConfigurationItem> landingUrl = configurationItemService.getByName(RECRUITMENT_LANDING_URL_NAME);
+        landingUrl.ifPresent(item -> landingUrlField.setValue(item.getValue()));
+
+        Optional<ConfigurationItem> alchemerStudyId = configurationItemService.getByName(RECRUITMENT_ALCHEMER_STUDY_ID_NAME);
+        alchemerStudyId.ifPresent(item -> alchemerStudyIdField.setValue(item.getValue()));
+
+        Optional<ConfigurationItem> retry = configurationItemService.getByName(RECRUITMENT_RETRY_NAME);
+        retry.ifPresent(item -> retryField.setValue(item.getValue()));
     }
 
-    private void saveRecruitmentMessage() {
-        Optional<ConfigurationItem> optionalRecruitmentMessage = configurationItemService.getByName(RECRUITMENT_MESSAGE_NAME);
-        ConfigurationItem recruitmentMessage = optionalRecruitmentMessage.orElse(new ConfigurationItem());
-        recruitmentMessage.setName(RECRUITMENT_MESSAGE_NAME);
-        recruitmentMessage.setValue(messageArea.getValue());
-        configurationItemService.update(recruitmentMessage);
-        Notification.show("Mensaje de reclutamiento guardado.");
+    private void saveConfiguration() {
+        // Introduction
+        Optional<ConfigurationItem> optionalIntroduction = configurationItemService.getByName(RECRUITMENT_INTRODUCTION_NAME);
+        ConfigurationItem introduction = optionalIntroduction.orElse(new ConfigurationItem());
+        introduction.setName(RECRUITMENT_INTRODUCTION_NAME);
+        introduction.setValue(introductionArea.getValue());
+        configurationItemService.update(introduction);
+
+        // Landing URL
+        Optional<ConfigurationItem> optionalLandingUrl = configurationItemService.getByName(RECRUITMENT_LANDING_URL_NAME);
+        ConfigurationItem landingUrl = optionalLandingUrl.orElse(new ConfigurationItem());
+        landingUrl.setName(RECRUITMENT_LANDING_URL_NAME);
+        landingUrl.setValue(landingUrlField.getValue());
+        configurationItemService.update(landingUrl);
+
+        // Alchemer Study ID
+        Optional<ConfigurationItem> optionalAlchemerStudyId = configurationItemService.getByName(RECRUITMENT_ALCHEMER_STUDY_ID_NAME);
+        ConfigurationItem alchemerStudyId = optionalAlchemerStudyId.orElse(new ConfigurationItem());
+        alchemerStudyId.setName(RECRUITMENT_ALCHEMER_STUDY_ID_NAME);
+        alchemerStudyId.setValue(alchemerStudyIdField.getValue());
+        configurationItemService.update(alchemerStudyId);
+
+        // Retry
+        Optional<ConfigurationItem> optionalRetry = configurationItemService.getByName(RECRUITMENT_RETRY_NAME);
+        ConfigurationItem retry = optionalRetry.orElse(new ConfigurationItem());
+        retry.setName(RECRUITMENT_RETRY_NAME);
+        retry.setValue(retryField.getValue());
+        configurationItemService.update(retry);
+
+        Notification.show("Configuración de reclutamiento guardada.");
     }
 }


### PR DESCRIPTION
This commit enhances the RecruitmentView with the following changes:

1.  Adds a read-only `TextArea` for the recruitment introduction.
2.  Adds a `TextField` for the landing page URL.
3.  Adds a `TextField` for the Alchemer study ID.
4.  Adds a `TextField` for the consent retry amount.

The view now loads and saves these new configuration items from the database.