### PR TITLE
feat: Agregar funcionalidad de importación de panelistas desde Excel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,16 @@
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
+	<dependency>
+	    <groupId>org.apache.poi</groupId>
+	    <artifactId>poi</artifactId>
+	    <version>5.2.3</version>
+	</dependency>
+	<dependency>
+	    <groupId>org.apache.poi</groupId>
+	    <artifactId>poi-ooxml</artifactId>
+	    <version>5.2.3</version>
+	</dependency>
 
     <!-- Test -->
     <dependency>

--- a/src/main/java/uy/com/equipos/panelmanagement/data/PanelistPropertyRepository.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/data/PanelistPropertyRepository.java
@@ -8,4 +8,5 @@ public interface PanelistPropertyRepository
             JpaRepository<PanelistProperty, Long>,
             JpaSpecificationExecutor<PanelistProperty> {
 
+    PanelistProperty findByName(String name);
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/services/PanelistPropertyService.java
@@ -63,4 +63,8 @@ public class PanelistPropertyService {
         return repository.findAll();
     }
 
+    public PanelistProperty findByName(String name) {
+        return repository.findByName(name);
+    }
+
 }

--- a/src/main/java/uy/com/equipos/panelmanagement/views/dialogs/ImportPanelistsDialog.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/dialogs/ImportPanelistsDialog.java
@@ -1,0 +1,197 @@
+package uy.com.equipos.panelmanagement.views.dialogs;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.component.upload.receivers.MemoryBuffer;
+import uy.com.equipos.panelmanagement.services.PanelistPropertyService;
+import uy.com.equipos.panelmanagement.services.PanelistService;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.grid.Grid;
+import uy.com.equipos.panelmanagement.data.PanelistProperty;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ImportPanelistsDialog extends Dialog {
+
+    private record ColumnMapping(String excelHeader, String panelistAttribute) {}
+
+    private static final Logger logger = LoggerFactory.getLogger(ImportPanelistsDialog.class);
+
+    private final PanelistService panelistService;
+    private final PanelistPropertyService panelistPropertyService;
+    private final Runnable onSuccessCallback;
+
+    private VerticalLayout contentLayout = new VerticalLayout();
+    private MemoryBuffer buffer = new MemoryBuffer();
+    private Upload upload = new Upload(buffer);
+    private byte[] fileContent;
+    private Button nextButton = new Button("Siguiente");
+    private Button closeButton = new Button("Cerrar");
+
+    public ImportPanelistsDialog(PanelistService panelistService, PanelistPropertyService panelistPropertyService, Runnable onSuccessCallback) {
+        this.panelistService = panelistService;
+        this.panelistPropertyService = panelistPropertyService;
+        this.onSuccessCallback = onSuccessCallback;
+
+        setHeaderTitle("Importar Panelistas (Paso 1 de 2)");
+
+        setupUpload();
+        setupButtons();
+
+        contentLayout.add(upload);
+        add(contentLayout);
+
+        getFooter().add(closeButton, nextButton);
+    }
+
+    private void setupUpload() {
+        upload.setAcceptedFileTypes(".xlsx", ".xls");
+        upload.setMaxFiles(1);
+        upload.addSucceededListener(event -> {
+            try (InputStream inputStream = buffer.getInputStream()) {
+                fileContent = inputStream.readAllBytes();
+                logger.info("Archivo {} subido exitosamente y guardado en memoria.", event.getFileName());
+                nextButton.setEnabled(true);
+            } catch (java.io.IOException e) {
+                logger.error("Error al leer el archivo subido", e);
+                Notification.show("Error al leer el archivo: " + e.getMessage(), 5000, Notification.Position.MIDDLE)
+                        .addThemeVariants(NotificationVariant.LUMO_ERROR);
+            }
+        });
+    }
+
+    private void setupButtons() {
+        nextButton.setEnabled(false);
+        nextButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        nextButton.addClickListener(e -> moveToStep2());
+
+        closeButton.addClickListener(e -> this.close());
+    }
+
+    private void moveToStep2() {
+        if (fileContent == null || fileContent.length == 0) {
+            Notification.show("No se ha subido ningún archivo o el archivo está vacío.", 3000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+            return;
+        }
+        try (InputStream inputStream = new java.io.ByteArrayInputStream(fileContent)) {
+            logger.info("Procesando archivo para pasar al paso 2.");
+            Workbook workbook = WorkbookFactory.create(inputStream);
+            Sheet sheet = workbook.getSheetAt(0);
+            Row headerRow = sheet.getRow(0);
+
+            if (headerRow == null) {
+                Notification.show("El archivo Excel no tiene una fila de encabezado.", 3000, Notification.Position.MIDDLE)
+                        .addThemeVariants(NotificationVariant.LUMO_ERROR);
+                return;
+            }
+
+            List<String> headers = new ArrayList<>();
+            for (Cell cell : headerRow) {
+                headers.add(cell.getStringCellValue());
+            }
+
+            logger.info("Encabezados encontrados: {}", headers);
+            showMappingScreen(headers);
+
+        } catch (Exception ex) {
+            logger.error("Error al procesar el archivo Excel", ex);
+            Notification.show("Error al leer el archivo Excel: " + ex.getMessage(), 5000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+        }
+    }
+
+    private void showMappingScreen(List<String> headers) {
+        setHeaderTitle("Importar Panelistas (Paso 2 de 2)");
+        contentLayout.removeAll();
+
+        Grid<ColumnMapping> grid = new Grid<>();
+        List<ColumnMapping> mappings = headers.stream().map(header -> new ColumnMapping(header, null)).collect(Collectors.toList());
+        grid.setItems(mappings);
+
+        List<String> panelistAttributes = Stream.concat(
+                Stream.of("Nombre", "Apellido", "E-mail", "Celular", "Fuente", "Id_En_Fuente"),
+                panelistPropertyService.findAll().stream().map(PanelistProperty::getName)
+        ).collect(Collectors.toList());
+
+        grid.addColumn(ColumnMapping::excelHeader).setHeader("Columna en Excel");
+
+        Map<String, ComboBox<String>> comboBoxes = new HashMap<>();
+        grid.addComponentColumn(mapping -> {
+            ComboBox<String> comboBox = new ComboBox<>();
+            comboBox.setItems(panelistAttributes);
+            comboBox.setPlaceholder("Seleccionar atributo...");
+            comboBoxes.put(mapping.excelHeader(), comboBox);
+            return comboBox;
+        }).setHeader("Atributo del Panelista");
+
+        contentLayout.add(grid);
+
+        Button backButton = new Button("Atrás", e -> showUploadScreen());
+        Button importButton = new Button("Importar", e -> {
+            Map<String, String> finalMappings = new HashMap<>();
+            for (Map.Entry<String, ComboBox<String>> entry : comboBoxes.entrySet()) {
+                if (entry.getValue().getValue() != null) {
+                    finalMappings.put(entry.getKey(), entry.getValue().getValue());
+                }
+            }
+            importPanelists(finalMappings);
+        });
+        importButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        getFooter().removeAll();
+        getFooter().add(backButton, importButton);
+    }
+
+    private void importPanelists(Map<String, String> mappings) {
+        if (fileContent == null || fileContent.length == 0) {
+            Notification.show("No se encontró contenido de archivo para importar.", 3000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+            return;
+        }
+        try {
+            int createdCount = panelistService.importPanelistsFromData(mappings, fileContent);
+            logger.info("Se han guardado {} panelistas.", createdCount);
+            Notification.show("Panelistas importados exitosamente: " + createdCount, 5000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+            if (onSuccessCallback != null) {
+                onSuccessCallback.run();
+            }
+            this.close();
+        } catch (Exception ex) {
+            logger.error("Error durante la importación de panelistas", ex);
+            Notification.show("Error durante la importación: " + ex.getMessage(), 5000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+        }
+    }
+
+    private void showUploadScreen() {
+        setHeaderTitle("Importar Panelistas (Paso 1 de 2)");
+        this.fileContent = null;
+        nextButton.setEnabled(false);
+        contentLayout.removeAll();
+        contentLayout.add(upload);
+        getFooter().removeAll();
+        getFooter().add(closeButton, nextButton);
+    }
+}

--- a/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
+++ b/src/main/java/uy/com/equipos/panelmanagement/views/panelists/PanelistsView.java
@@ -66,6 +66,7 @@ import uy.com.equipos.panelmanagement.services.PanelService; // Added
 import uy.com.equipos.panelmanagement.services.PanelistPropertyService;
 import uy.com.equipos.panelmanagement.services.PanelistPropertyValueService;
 import uy.com.equipos.panelmanagement.services.PanelistService;
+import uy.com.equipos.panelmanagement.views.dialogs.ImportPanelistsDialog;
 import uy.com.equipos.panelmanagement.views.dialogs.PanelistResultsDialog; // Importar el nuevo diálogo
 import uy.com.equipos.panelmanagement.views.panels.PanelistPropertyFilterDialog; // Importar la clase del diálogo
 
@@ -110,6 +111,7 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 	private final Button save = new Button("Guardar");
 	private Button deleteButton; // Add this with other button declarations
 	private Button nuevoPanelistaButton;
+	private Button importPanelistsButton;
 	// private Button gestionarPropiedadesButton; // Removed duplicate declaration
 	private Button viewParticipatingPanelsButton;
 	private Button viewParticipatingSurveysButton; // Added
@@ -194,6 +196,12 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 		nuevoPanelistaButton = new Button("Nuevo Panelista");
 		nuevoPanelistaButton.getStyle().set("margin-left", "18px");
 
+		importPanelistsButton = new Button("Importar panelistas");
+        importPanelistsButton.addClickListener(e -> {
+            ImportPanelistsDialog dialog = new ImportPanelistsDialog(panelistService, panelistPropertyService, this::refreshGrid);
+            dialog.open();
+        });
+
 		Button filtrarPanelistasButton = new Button("Filtrar Panelistas");
 		filtrarPanelistasButton.addClickListener(e -> {
 			PanelistPropertyFilterDialog filterDialog = new PanelistPropertyFilterDialog(panelistPropertyService,
@@ -209,7 +217,7 @@ public class PanelistsView extends Div implements BeforeEnterObserver {
 			filterDialog.open();
 		});
 
-		HorizontalLayout buttonBar = new HorizontalLayout(nuevoPanelistaButton, filtrarPanelistasButton);
+		HorizontalLayout buttonBar = new HorizontalLayout(nuevoPanelistaButton, importPanelistsButton, filtrarPanelistasButton);
 		buttonBar.setAlignItems(Alignment.CENTER); // Alinea los botones verticalmente si tienen diferentes alturas
 		buttonBar.getStyle().set("margin-left", "18px");
 


### PR DESCRIPTION
Se agrega un botón "Importar panelistas" en la vista de Panelistas que abre un asistente de dos pasos para importar datos desde un archivo Excel.

Características principales:
- **Asistente de Importación:** Un diálogo de dos pasos guía al usuario a través del proceso.
- **Paso 1: Carga de Archivo:** El usuario puede subir un archivo .xls o .xlsx.
- **Paso 2: Mapeo de Columnas:** Se muestra una grilla donde el usuario puede mapear las columnas del archivo Excel a los atributos del panelista. Los atributos incluyen campos fijos (Nombre, Apellido, E-mail, etc.) y propiedades dinámicas (`PanelistProperty`) definidas en el sistema.
- **Lógica de Negocio en Servicio:** La lógica de procesamiento del archivo y la creación de entidades se ha movido a un método transaccional en `PanelistService` para garantizar la atomicidad y la integridad de los datos.
- **Manejo de Errores y Feedback:** El sistema proporciona notificaciones claras en caso de éxito o error y actualiza la grilla principal después de una importación exitosa.
- **Robustez:** Se han implementado mejoras para manejar correctamente la navegación en el asistente y para omitir filas vacías en el archivo Excel.